### PR TITLE
[Issue 21] All the tests classes should be labelled correctly

### DIFF
--- a/src/Math-Tests-KernelSmoothing/PMSmoothedDensityTest.class.st
+++ b/src/Math-Tests-KernelSmoothing/PMSmoothedDensityTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'density'
 	],
-	#category : 'Math-KernelSmoothing'
+	#category : #'Math-Tests-KernelSmoothing'
 }
 
 { #category : #running }

--- a/src/Math-Tests-KernelSmoothing/package.st
+++ b/src/Math-Tests-KernelSmoothing/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Math-Tests-KernelSmoothing' }

--- a/src/Math-Tests-Number-Extensions/NumberExtensionsTest.class.st
+++ b/src/Math-Tests-Number-Extensions/NumberExtensionsTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #NumberExtensionsTest,
 	#superclass : #TestCase,
-	#category : #'Math-Number-Extensions'
+	#category : #'Math-Tests-Number-Extensions'
 }
 
 { #category : #tests }

--- a/src/Math-Tests-Number-Extensions/package.st
+++ b/src/Math-Tests-Number-Extensions/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Math-Tests-Number-Extensions' }

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
@@ -7,7 +7,7 @@ Class {
 		'accumulator',
 		'server'
 	],
-	#category : 'Math-PrincipalComponentAnalysis'
+	#category : #'Math-Tests-PrincipalComponentAnalysis'
 }
 
 { #category : #tests }

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMStandardizationScalerTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMStandardizationScalerTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PMStandardizationScalerTest,
 	#superclass : #TestCase,
-	#category : #'Math-PrincipalComponentAnalysis'
+	#category : #'Math-Tests-PrincipalComponentAnalysis'
 }
 
 { #category : #tests }

--- a/src/Math-Tests-PrincipalComponentAnalysis/package.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Math-Tests-PrincipalComponentAnalysis' }

--- a/src/Math-Tests-RandomDistributionBased/PMLaplaceGeneratorTest.class.st
+++ b/src/Math-Tests-RandomDistributionBased/PMLaplaceGeneratorTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PMLaplaceGeneratorTest,
 	#superclass : #TestCase,
-	#category : 'Math-RandomDistributionBased'
+	#category : #'Math-Tests-RandomDistributionBased'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Math-Tests-RandomDistributionBased/package.st
+++ b/src/Math-Tests-RandomDistributionBased/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Math-Tests-RandomDistributionBased' }


### PR DESCRIPTION
Moved the test classes to more sensible packages, named in accordance with the existing convention, see [issue 21](https://github.com/PolyMathOrg/PolyMath/issues/21)

As a check, I ran each test and made sure it was green. Two tests were found to be failing and have been identified [here](https://groups.google.com/forum/#!topic/polymath-project/IzdF072lpoY).