### PR TITLE
[issue-85] All Test Classes Should Be Labelled Correctly (Part 2)

### DIFF
--- a/src/Math-Tests-Permutation/PMPermutationTest.class.st
+++ b/src/Math-Tests-Permutation/PMPermutationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PMPermutationTest,
 	#superclass : #TestCase,
-	#category : #'Math-Permutation'
+	#category : #'Math-Tests-Permutation'
 }
 
 { #category : #'class tests' }

--- a/src/Math-Tests-Permutation/package.st
+++ b/src/Math-Tests-Permutation/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Math-Tests-Permutation' }

--- a/src/Math-Tests-TSNE/TSNETest.class.st
+++ b/src/Math-Tests-TSNE/TSNETest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #TSNETest,
 	#superclass : #TestCase,
-	#category : 'Math-TSNE'
+	#category : #'Math-Tests-TSNE'
 }
 
 { #category : #tests }

--- a/src/Math-Tests-TSNE/package.st
+++ b/src/Math-Tests-TSNE/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Math-Tests-TSNE' }


### PR DESCRIPTION
This addresses issue 85, where some other `TestCase` classes were found to be in production packages.
As a check, after moving the `TestCase` classes, I ran them in their new packages and they were all green.