### PR TITLE
[issue-88] Corrected the type.

### DIFF
--- a/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
@@ -16,7 +16,7 @@ PMPrincipalComponentAnalyserTest >> testPCAwithPCAandJacobiTransformationReturnS
 	m := PMMatrix rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
 	pca1 := PMPrincipalComponentAnalyserSVD new componentsNumber: 2.
 	pca1 fit: m.
-	pca2 := PMPrincipalComponentAnalyserSVD new componentsNumber: 2.
+	pca2 := PMPrincipalComponentAnalyserJacobiTransformation new componentsNumber: 2.
 	pca2 fit: m.
 	self assert: pca1 transformMatrix closeTo: pca2 transformMatrix
 ]


### PR DESCRIPTION
This address issue #88, where `pca2` was the SVD-based implementation whereas it should be the Jacobi Transformation. 

After making the change the test continued to pass.