### PR TITLE
[Issue 81] 2 PCA implementations that give same results but different from Python scikit-learn implementation

### DIFF
--- a/src/Math-Core/PMVector.class.st
+++ b/src/Math-Core/PMVector.class.st
@@ -115,8 +115,16 @@ PMVector >> accumulateNegated: aVectorOrAnArray [
 
 { #category : #'as yet unclassified' }
 PMVector >> argMax [
+	| precision |
+	precision := 1.0e-10.
+	^ self argMaxTo: precision
+]
+
+{ #category : #'as yet unclassified' }
+PMVector >> argMaxTo: roundingPrecision [
 	| a |
-	a := self asArray.
+	a := self asArray
+		collect: [ :element | element truncateTo: roundingPrecision ].
 	^ a indexOf: a max
 ]
 

--- a/src/Math-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserSVD.class.st
+++ b/src/Math-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserSVD.class.st
@@ -50,7 +50,7 @@ PMPrincipalComponentAnalyserSVD >> flipEigenvectorsSign [
 	"U-based decision like : https://github.com/scikit-learn/scikit-learn/blob/4c65d8e615c9331d37cbb6225c5b67c445a5c959/sklearn/utils/extmath.py#L609"
 	
 	| algo |
-	algo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
+	algo := SciKitLearnEigenvectorFlipAlgorithm flipU: u andV: v.
 	
 	u := algo uFlipped . 
 	v := algo vFlipped . 

--- a/src/Math-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserSVD.class.st
+++ b/src/Math-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserSVD.class.st
@@ -49,14 +49,11 @@ PMPrincipalComponentAnalyserSVD >> flipEigenvectorsSign [
 	"flip eigenvectors sign to enforce deterministic output"
 	"U-based decision like : https://github.com/scikit-learn/scikit-learn/blob/4c65d8e615c9331d37cbb6225c5b67c445a5c959/sklearn/utils/extmath.py#L609"
 	
-	"does not work at the moment"
-	| signs maxAbsCols i |
-	maxAbsCols := (u abs) argMaxOnColumns.
-	i := 0.
-	signs := (u rowsCollect: [ :each| i := i + 1. each at: (maxAbsCols at: i)
-		]) sign.
-	u := u * signs.
-	v := v productWithVector: (signs copyFrom:1 to: v numberOfColumns)
+	| algo |
+	algo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
+	
+	u := algo uFlipped . 
+	v := algo vFlipped . 
 ]
 
 { #category : #accessing }

--- a/src/Math-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserSVD.class.st
+++ b/src/Math-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserSVD.class.st
@@ -37,11 +37,11 @@ d1 scatterplotMatrix.
 
 { #category : #accessing }
 PMPrincipalComponentAnalyserSVD >> fit: aPMMatrix [
-	svd := PMSingularValueDecomposition new initialize: aPMMatrix.
+	svd := aPMMatrix decompose.
 	u := svd leftSingularForm.
 	v := svd rightSingularForm.
-	"self flipEigenvectorsSign"
-	"flip does not work correctly at the moment"
+	self flipEigenvectorsSign
+	
 ]
 
 { #category : #accessing }

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -43,10 +43,8 @@ SciKitLearnEigenvectorFlipAlgorithm >> flipSign [
 
 	"does not work at the moment"
 
-	| matrixForV |
 	u := u rowsCollect: [ :row | row dot: signs ].
-	matrixForV := self signMatrixForV.
-	v := v dot: matrixForV
+	v := v dot: (self signMatrixForV)
 ]
 
 { #category : #initialization }

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -11,7 +11,9 @@ Class {
 	#instVars : [
 		'u',
 		'v',
-		'signs'
+		'signs',
+		'uFlipped',
+		'vFlipped'
 	],
 	#category : #'Math-PrincipalComponentAnalysis'
 }
@@ -41,8 +43,8 @@ SciKitLearnEigenvectorFlipAlgorithm >> flipSign [
 
 	"U-based decision like : https://github.com/scikit-learn/scikit-learn/blob/4c65d8e615c9331d37cbb6225c5b67c445a5c959/sklearn/utils/extmath.py#L609"
 
-	u := u rowsCollect: [ :row | row dot: signs ].
-	v := v dot: (self signMatrixForV)
+	uFlipped := u rowsCollect: [ :row | row dot: signs ].
+	vFlipped := v dot: (self signMatrixForV)
 ]
 
 { #category : #initialization }
@@ -92,6 +94,16 @@ SciKitLearnEigenvectorFlipAlgorithm >> u [
 ]
 
 { #category : #accessing }
+SciKitLearnEigenvectorFlipAlgorithm >> uFlipped [
+	^ uFlipped .
+]
+
+{ #category : #accessing }
 SciKitLearnEigenvectorFlipAlgorithm >> v [
 	^v
+]
+
+{ #category : #accessing }
+SciKitLearnEigenvectorFlipAlgorithm >> vFlipped [
+	^ vFlipped .
 ]

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -35,16 +35,6 @@ SciKitLearnEigenvectorFlipAlgorithm >> computeSignsFromU [
 	^ maxElements sign asPMVector 
 ]
 
-{ #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> flipSign [
-	"flip eigenvectors sign to enforce deterministic output"
-
-	"U-based decision like : https://github.com/scikit-learn/scikit-learn/blob/4c65d8e615c9331d37cbb6225c5b67c445a5c959/sklearn/utils/extmath.py#L609"
-
-	uFlipped := u rowsCollect: [ :row | row dot: signs ].
-	vFlipped := v dot: (self signMatrixForV)
-]
-
 { #category : #initialization }
 SciKitLearnEigenvectorFlipAlgorithm >> initializeWithU: uMatrix andV: vMatrix [
 	"instantiate the algorithm"

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -41,8 +41,6 @@ SciKitLearnEigenvectorFlipAlgorithm >> flipSign [
 
 	"U-based decision like : https://github.com/scikit-learn/scikit-learn/blob/4c65d8e615c9331d37cbb6225c5b67c445a5c959/sklearn/utils/extmath.py#L609"
 
-	"does not work at the moment"
-
 	u := u rowsCollect: [ :row | row dot: signs ].
 	v := v dot: (self signMatrixForV)
 ]

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -17,7 +17,7 @@ Class {
 }
 
 { #category : #'instance creation' }
-SciKitLearnEigenvectorFlipAlgorithm class >> u: u v: v [
+SciKitLearnEigenvectorFlipAlgorithm class >> flipU: u andV: v [
 	^ self new
 		initializeWithU: u andV: v;
 		yourself

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -90,10 +90,10 @@ SciKitLearnEigenvectorFlipAlgorithm >> signs [
 
 { #category : #accessing }
 SciKitLearnEigenvectorFlipAlgorithm >> uFlipped [
-	^ uFlipped .
+	^ PMMatrix rows: (u rowsCollect: [ :row | row dot: signs ]).
 ]
 
 { #category : #accessing }
 SciKitLearnEigenvectorFlipAlgorithm >> vFlipped [
-	^ vFlipped .
+	^ v dot: (self signMatrixForV) .
 ]

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -43,10 +43,24 @@ SciKitLearnEigenvectorFlipAlgorithm >> flipSign [
 
 	"does not work at the moment"
 
-	| signs |
+	| signs matrixForV |
 	signs := self computeSignsFromU.
-	u := u * signs.
-	v := v * (signs copyFrom: 1 to: v numberOfColumns)
+	u := u rowsCollect: [ :row | row dot: signs ].
+	matrixForV := self signMatrixForV: signs.
+	v := v dot: matrixForV
+]
+
+{ #category : #accessing }
+SciKitLearnEigenvectorFlipAlgorithm >> signMatrixForV: signs [
+	| signsForV |
+	signsForV := signs copyFrom: 1 to: v numberOfColumns.
+	^ PMMatrix
+		rows:
+			((1 to: v numberOfRows)
+				inject: OrderedCollection new
+				into: [ :rows :eachRow | 
+					rows add: signsForV.
+					rows ])
 ]
 
 { #category : #accessing }

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -25,13 +25,14 @@ SciKitLearnEigenvectorFlipAlgorithm class >> u: u v: v [
 
 { #category : #accessing }
 SciKitLearnEigenvectorFlipAlgorithm >> computeSignsFromU [
-	| maxAbsCols i |
+	| maxAbsCols i maxElements |
 	maxAbsCols := u abs argMaxOnColumns.
 	i := 0.
-	^ (u
+	maxElements := u transpose 
 		rowsCollect: [ :each | 
 			i := i + 1.
-			each at: (maxAbsCols at: i) ]) sign
+			each at: (maxAbsCols at: i) ].
+	^ maxElements sign
 ]
 
 { #category : #accessing }
@@ -45,7 +46,7 @@ SciKitLearnEigenvectorFlipAlgorithm >> flipSign [
 	| signs |
 	signs := self computeSignsFromU.
 	u := u * signs.
-	v := v productWithVector: (signs copyFrom: 1 to: v numberOfColumns)
+	v := v * (signs copyFrom: 1 to: v numberOfColumns)
 ]
 
 { #category : #accessing }

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -24,7 +24,7 @@ SciKitLearnEigenvectorFlipAlgorithm class >> u: u v: v [
 ]
 
 { #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> computeSigns [
+SciKitLearnEigenvectorFlipAlgorithm >> computeSignsFromU [
 	| maxAbsCols i |
 	maxAbsCols := u abs argMaxOnColumns.
 	i := 0.
@@ -43,7 +43,7 @@ SciKitLearnEigenvectorFlipAlgorithm >> flipSign [
 	"does not work at the moment"
 
 	| signs |
-	signs := self computeSigns.
+	signs := self computeSignsFromU.
 	u := u * signs.
 	v := v productWithVector: (signs copyFrom: 1 to: v numberOfColumns)
 ]

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -73,14 +73,14 @@ SciKitLearnEigenvectorFlipAlgorithm >> signMatrixForU [
 SciKitLearnEigenvectorFlipAlgorithm >> signMatrixForV [
 	| signsForV |
 	signsForV := self signs copyFrom: 1 to: v numberOfColumns.
-	^ PMMatrix
+	^ (PMMatrix
 		rows:
 			((1 to: v numberOfRows)
 				inject: OrderedCollection new
 				into: [ :rows :eachRow | 
 					rows
 						add: signsForV;
-						yourself ])
+						yourself ])) transpose
 ]
 
 { #category : #accessing }

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -38,8 +38,8 @@ SciKitLearnEigenvectorFlipAlgorithm >> computeSignsFromU [
 { #category : #initialization }
 SciKitLearnEigenvectorFlipAlgorithm >> initializeWithU: uMatrix andV: vMatrix [
 	"instantiate the algorithm"
-	u := uMatrix.
-	v := vMatrix.
+	u := uMatrix .
+	v := vMatrix .
 	signs := self computeSignsFromU .
 
 

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -1,0 +1,69 @@
+"
+This class uses the SciKit-Learn SVD flip algorithm to ensure the signs of the eigenvectors correlate with the trend of the data.
+    Instance Variables
+	u:		PMMatrix
+	v:		PMMatrix
+
+"
+Class {
+	#name : #SciKitLearnEigenvectorFlipAlgorithm,
+	#superclass : #Object,
+	#instVars : [
+		'u',
+		'v'
+	],
+	#category : #'Math-PrincipalComponentAnalysis'
+}
+
+{ #category : #'instance creation' }
+SciKitLearnEigenvectorFlipAlgorithm class >> u: u v: v [
+	^ self new
+		u: u;
+		v: v;
+		yourself
+]
+
+{ #category : #accessing }
+SciKitLearnEigenvectorFlipAlgorithm >> computeSigns [
+	| maxAbsCols i |
+	maxAbsCols := u abs argMaxOnColumns.
+	i := 0.
+	^ (u
+		rowsCollect: [ :each | 
+			i := i + 1.
+			each at: (maxAbsCols at: i) ]) sign
+]
+
+{ #category : #accessing }
+SciKitLearnEigenvectorFlipAlgorithm >> flipSign [
+	"flip eigenvectors sign to enforce deterministic output"
+
+	"U-based decision like : https://github.com/scikit-learn/scikit-learn/blob/4c65d8e615c9331d37cbb6225c5b67c445a5c959/sklearn/utils/extmath.py#L609"
+
+	"does not work at the moment"
+
+	| signs |
+	signs := self computeSigns.
+	u := u * signs.
+	v := v productWithVector: (signs copyFrom: 1 to: v numberOfColumns)
+]
+
+{ #category : #accessing }
+SciKitLearnEigenvectorFlipAlgorithm >> u [
+	^u
+]
+
+{ #category : #accessing }
+SciKitLearnEigenvectorFlipAlgorithm >> u: leftSingularVectors [
+	u := leftSingularVectors 
+]
+
+{ #category : #accessing }
+SciKitLearnEigenvectorFlipAlgorithm >> v [
+	^v
+]
+
+{ #category : #accessing }
+SciKitLearnEigenvectorFlipAlgorithm >> v: rightSingularVectors [
+	v := rightSingularVectors.
+]

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -11,9 +11,7 @@ Class {
 	#instVars : [
 		'u',
 		'v',
-		'signs',
-		'uFlipped',
-		'vFlipped'
+		'signs'
 	],
 	#category : #'Math-PrincipalComponentAnalysis'
 }

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -78,7 +78,7 @@ SciKitLearnEigenvectorFlipAlgorithm >> signs [
 
 { #category : #accessing }
 SciKitLearnEigenvectorFlipAlgorithm >> uFlipped [
-	^ PMMatrix rows: (u rowsCollect: [ :row | row dot: signs ]).
+	^ u dot: (self signMatrixForU).
 ]
 
 { #category : #accessing }

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -32,7 +32,7 @@ SciKitLearnEigenvectorFlipAlgorithm >> computeSignsFromU [
 		rowsCollect: [ :each | 
 			i := i + 1.
 			each at: (maxAbsCols at: i) ].
-	^ maxElements sign
+	^ maxElements sign asPMVector 
 ]
 
 { #category : #accessing }

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -49,7 +49,7 @@ SciKitLearnEigenvectorFlipAlgorithm >> flipSign [
 
 { #category : #initialization }
 SciKitLearnEigenvectorFlipAlgorithm >> initializeWithU: uMatrix andV: vMatrix [
-	"instanciate the algorithm"
+	"instantiate the algorithm"
 	u := uMatrix.
 	v := vMatrix.
 	signs := self computeSignsFromU .

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -10,7 +10,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'u',
-		'v'
+		'v',
+		'signs'
 	],
 	#category : #'Math-PrincipalComponentAnalysis'
 }
@@ -18,8 +19,7 @@ Class {
 { #category : #'instance creation' }
 SciKitLearnEigenvectorFlipAlgorithm class >> u: u v: v [
 	^ self new
-		u: u;
-		v: v;
+		initializeWithU: u andV: v;
 		yourself
 ]
 
@@ -43,24 +43,39 @@ SciKitLearnEigenvectorFlipAlgorithm >> flipSign [
 
 	"does not work at the moment"
 
-	| signs matrixForV |
-	signs := self computeSignsFromU.
+	| matrixForV |
 	u := u rowsCollect: [ :row | row dot: signs ].
-	matrixForV := self signMatrixForV: signs.
+	matrixForV := self signMatrixForV.
 	v := v dot: matrixForV
 ]
 
+{ #category : #initialization }
+SciKitLearnEigenvectorFlipAlgorithm >> initializeWithU: uMatrix andV: vMatrix [
+	"instanciate the algorithm"
+	u := uMatrix.
+	v := vMatrix.
+	signs := self computeSignsFromU .
+
+
+]
+
 { #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> signMatrixForV: signs [
+SciKitLearnEigenvectorFlipAlgorithm >> signMatrixForV [
 	| signsForV |
-	signsForV := signs copyFrom: 1 to: v numberOfColumns.
+	signsForV := self signs copyFrom: 1 to: v numberOfColumns.
 	^ PMMatrix
 		rows:
 			((1 to: v numberOfRows)
 				inject: OrderedCollection new
 				into: [ :rows :eachRow | 
-					rows add: signsForV.
-					rows ])
+					rows
+						add: signsForV;
+						yourself ])
+]
+
+{ #category : #accessing }
+SciKitLearnEigenvectorFlipAlgorithm >> signs [
+	^ signs
 ]
 
 { #category : #accessing }
@@ -69,16 +84,6 @@ SciKitLearnEigenvectorFlipAlgorithm >> u [
 ]
 
 { #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> u: leftSingularVectors [
-	u := leftSingularVectors 
-]
-
-{ #category : #accessing }
 SciKitLearnEigenvectorFlipAlgorithm >> v [
 	^v
-]
-
-{ #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> v: rightSingularVectors [
-	v := rightSingularVectors.
 ]

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -58,6 +58,18 @@ SciKitLearnEigenvectorFlipAlgorithm >> initializeWithU: uMatrix andV: vMatrix [
 ]
 
 { #category : #accessing }
+SciKitLearnEigenvectorFlipAlgorithm >> signMatrixForU [
+	^ PMMatrix
+		rows:
+			((1 to: u numberOfRows)
+				inject: OrderedCollection new
+				into: [ :rows :eachRow | 
+					rows
+						add: signs;
+						yourself ])
+]
+
+{ #category : #accessing }
 SciKitLearnEigenvectorFlipAlgorithm >> signMatrixForV [
 	| signsForV |
 	signsForV := self signs copyFrom: 1 to: v numberOfColumns.

--- a/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithm.class.st
@@ -89,18 +89,8 @@ SciKitLearnEigenvectorFlipAlgorithm >> signs [
 ]
 
 { #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> u [
-	^u
-]
-
-{ #category : #accessing }
 SciKitLearnEigenvectorFlipAlgorithm >> uFlipped [
 	^ uFlipped .
-]
-
-{ #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> v [
-	^v
 ]
 
 { #category : #accessing }

--- a/src/Math-Tests-DHB-Numerical/PMVectorTest.class.st
+++ b/src/Math-Tests-DHB-Numerical/PMVectorTest.class.st
@@ -44,6 +44,17 @@ PMVectorTest >> testArgMax [
 ]
 
 { #category : #tests }
+PMVectorTest >> testArgMaxWithVectorOverReals [
+	"For vectors over a field of real numbers"
+
+	| v1 v2 |
+	v1 := #(1.3 5.001 3.1 2.0 0.2) asPMVector.
+	v2 := #(1.2 15.0000000200 3.14 15.0000000201 0.1) asPMVector.
+	self assert: v1 argMax equals: 2.
+	self assert: v2 argMax equals: 4
+]
+
+{ #category : #tests }
 PMVectorTest >> testAsArray [
 	self assert: #(1 2 3 4) asPMVector asArray equals: #(1 2 3 4)
 ]

--- a/src/Math-Tests-Matrix/PMJacobiTransformationTest.class.st
+++ b/src/Math-Tests-Matrix/PMJacobiTransformationTest.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #PMJacobiTransformationTest,
+	#superclass : #TestCase,
+	#category : #'Math-Tests-Matrix'
+}
+
+{ #category : #tests }
+PMJacobiTransformationTest >> testEigenvalueOfIdentityMatrixIsOne [
+	"The eigenvalue of I is 1"
+
+	| jacobiTransformation identityMatrix expected |
+	identityMatrix := PMMatrix rows: #(#(1 0) #(0 1)).
+	
+	jacobiTransformation := PMJacobiTransformation matrix: identityMatrix.
+	
+	expected := #(1 1).
+	self assert: jacobiTransformation evaluate equals: expected
+]

--- a/src/Math-Tests-Matrix/PMJacobiTransformationTest.class.st
+++ b/src/Math-Tests-Matrix/PMJacobiTransformationTest.class.st
@@ -16,3 +16,19 @@ PMJacobiTransformationTest >> testEigenvalueOfIdentityMatrixIsOne [
 	expected := #(1 1).
 	self assert: jacobiTransformation evaluate equals: expected
 ]
+
+{ #category : #tests }
+PMJacobiTransformationTest >> testEigenvectorsOfIdentityMatrixAreTheUnitVectors [
+	"The eigenvectors of I are (1 0) and (0 1), the unit basis vectors"
+
+	| identityMatrix jacobiTransform eigenvectors xUnitVector yUnitVector |
+	identityMatrix := PMMatrix rows: #(#(1 0) #(0 1)).
+	jacobiTransform := PMJacobiTransformation matrix: identityMatrix.
+	
+	eigenvectors := jacobiTransform transform.
+	
+	xUnitVector := #(1 0) asPMVector.
+	self assert: (eigenvectors columnAt: 1) equals: xUnitVector.
+	yUnitVector := #(0 1) asPMVector.
+	self assert: (eigenvectors columnAt: 2) equals: yUnitVector.
+]

--- a/src/Math-Tests-Matrix/PMJacobiTransformationTest.class.st
+++ b/src/Math-Tests-Matrix/PMJacobiTransformationTest.class.st
@@ -21,14 +21,12 @@ PMJacobiTransformationTest >> testEigenvalueOfIdentityMatrixIsOne [
 PMJacobiTransformationTest >> testEigenvectorsOfIdentityMatrixAreTheUnitVectors [
 	"The eigenvectors of I are (1 0) and (0 1), the unit basis vectors"
 
-	| identityMatrix jacobiTransform eigenvectors xUnitVector yUnitVector |
+	| identityMatrix jacobiTransform matrixOfEigenvectors expected |
 	identityMatrix := PMMatrix rows: #(#(1 0) #(0 1)).
 	jacobiTransform := PMJacobiTransformation matrix: identityMatrix.
 	
-	eigenvectors := jacobiTransform transform.
+	matrixOfEigenvectors := jacobiTransform transform.
 	
-	xUnitVector := #(1 0) asPMVector.
-	self assert: (eigenvectors columnAt: 1) equals: xUnitVector.
-	yUnitVector := #(0 1) asPMVector.
-	self assert: (eigenvectors columnAt: 2) equals: yUnitVector.
+	expected := PMSymmetricMatrix identity: 2.
+	self assert: matrixOfEigenvectors equals: expected.
 ]

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -29,7 +29,7 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
 
 { #category : #tests }
 SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForU [
-	"We compute a matrix of signs for u with which
+	"We compute a matrix of signs for U with which
 	we perform a 'dot product' with the original
 	matrix V
 	(by 'dot product' we mean send the dot: message)

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -9,7 +9,7 @@ Class {
 }
 
 { #category : #tests }
-SciKitLearnEigenvectorFlipAlgorithmTest >> testFlipEigenvectorsSign [
+SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
 	"The purpose is to compare the output from fligEigenVectorsSign in
 	PolyMath with scikit-learn
 	"
@@ -23,6 +23,6 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testFlipEigenvectorsSign [
 	
 	signs := flipAlgorithm computeSignsFromU .
 	
-	expected := #(-1 -1 -1 1 1 -1) asPMVector.
+	expected := #(-1 1 1 1 1 1) asPMVector .
 	self assert: signs equals: expected
 ]

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -26,3 +26,41 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
 	expected := #(-1 1 1 1 1 1) asPMVector .
 	self assert: signs equals: expected
 ]
+
+{ #category : #tests }
+SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForV [
+	"We compute a matrix of signs for V with which
+	we perform a 'dot product' with the original
+	matrix V
+	(by 'dot product' we mean send the dot: message)
+	Example here is taken from Scikit Learn
+	
+	U = [[-0.21956688  0.53396977]
+ 		 [-0.35264795 -0.45713538]
+ 		 [-0.57221483  0.07683439]
+ 		 [ 0.21956688 -0.53396977]
+ 	    [ 0.35264795  0.45713538]
+ 	    [ 0.57221483 -0.07683439]]
+
+   V = [[ 0.83849224  0.54491354]
+ 		 [ 0.54491354 -0.83849224]]    
+	"
+
+	| u v signAlgo signs expected |
+	u := PMMatrix rows: #(
+		#(-0.21956688 0.53396977) 
+		#(-0.35264795 -0.45713538) 
+		#(-0.57221483  0.07683439) 
+		#( 0.21956688 -0.53396977) 
+		#( 0.35264795  0.45713538) 
+		#( 0.57221483 -0.07683439)).
+	v := PMMatrix rows: #(
+		#(0.83849224  0.54491354) 
+		#(0.54491354 -0.83849224)).
+	signs := #(-1 1 1 1 1 1) asPMVector .
+	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
+	
+	
+	expected := PMMatrix rows: #(#(-1 1) #(-1 1)).
+	self assert: (signAlgo signMatrixForV: signs) equals: expected
+]

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -32,16 +32,13 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
 	PolyMath with scikit-learn
 	"
 
-	| m u v flipAlgorithm svd expected signs |
-	m := PMMatrix rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
-	svd := PMSingularValueDecomposition new initialize: m.
-	u := svd leftSingularForm.
-	v := svd rightSingularForm.
+	| flipAlgorithm expected signs |
+	self setUpScikitLearnExample .
 	flipAlgorithm := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
 	
 	signs := flipAlgorithm computeSignsFromU .
 	
-	expected := #(-1 1 1 1 1 1) asPMVector .
+	expected := #(-1 1) asPMVector .
 	self assert: signs equals: expected
 ]
 

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -96,7 +96,7 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForV [
 		#(0.54491354 -0.83849224)).
 	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
 	
-	expected := PMMatrix rows: #(#(-1 1) #(-1 1)).
+	expected := PMMatrix rows: #(#(-1 -1) #(1 1)).
 	self assert: (signAlgo signMatrixForV) equals: expected
 ]
 
@@ -138,6 +138,44 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testUFlipped [
  						#(-0.57221483 -0.07683439)).
 
 	self assert: (signAlgo uFlipped) equals: expected
+
+	
+]
+
+{ #category : #tests }
+SciKitLearnEigenvectorFlipAlgorithmTest >> testVFlipped [
+	"Here we calculate the U matrix with its signs flipped 
+	Example here is taken from Scikit Learn
+	
+	U = [[-0.21956688  0.53396977]
+ 		 [-0.35264795 -0.45713538]
+ 		 [-0.57221483  0.07683439]
+ 		 [ 0.21956688 -0.53396977]
+ 	    [ 0.35264795  0.45713538]
+ 	    [ 0.57221483 -0.07683439]]
+
+   V = [[ 0.83849224  0.54491354]
+ 		 [ 0.54491354 -0.83849224]]    
+	"
+
+	| u v signAlgo expected |
+	u := PMMatrix rows: #(
+		#(-0.21956688 0.53396977) 
+		#(-0.35264795 -0.45713538) 
+		#(-0.57221483  0.07683439) 
+		#( 0.21956688 -0.53396977) 
+		#( 0.35264795  0.45713538) 
+		#( 0.57221483 -0.07683439)).
+	v := PMMatrix rows: #(
+		#(0.83849224  0.54491354) 
+		#(0.54491354 -0.83849224)).
+	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
+	
+	expected := PMMatrix rows: #(
+					 #(-0.83849224 -0.54491354)
+ 					 #(0.54491354 -0.83849224)).
+
+	self assert: (signAlgo vFlipped) equals: expected
 
 	
 ]

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -14,6 +14,24 @@ Class {
 
 { #category : #initialization }
 SciKitLearnEigenvectorFlipAlgorithmTest >> setUpScikitLearnExample [
+"  We compute a matrix of signs for U with which
+	we perform a 'dot product' with the original
+	matrix V
+	(by 'dot product' we mean send the dot: message)
+	Example here is taken from Scikit Learn
+	
+	U = [[-0.21956688  0.53396977]
+ 		 [-0.35264795 -0.45713538]
+ 		 [-0.57221483  0.07683439]
+ 		 [ 0.21956688 -0.53396977]
+ 	    [ 0.35264795  0.45713538]
+ 	    [ 0.57221483 -0.07683439]]
+
+   V = [[ 0.83849224  0.54491354]
+ 		 [ 0.54491354 -0.83849224]]    
+	"
+
+
 	u := PMMatrix rows: #(
 		#(-0.21956688 0.53396977) 
 		#(-0.35264795 -0.45713538) 
@@ -44,23 +62,6 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
 
 { #category : #tests }
 SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForU [
-	"We compute a matrix of signs for U with which
-	we perform a 'dot product' with the original
-	matrix V
-	(by 'dot product' we mean send the dot: message)
-	Example here is taken from Scikit Learn
-	
-	U = [[-0.21956688  0.53396977]
- 		 [-0.35264795 -0.45713538]
- 		 [-0.57221483  0.07683439]
- 		 [ 0.21956688 -0.53396977]
- 	    [ 0.35264795  0.45713538]
- 	    [ 0.57221483 -0.07683439]]
-
-   V = [[ 0.83849224  0.54491354]
- 		 [ 0.54491354 -0.83849224]]    
-	"
-
 	| signAlgo expected |
 	self setUpScikitLearnExample .
 	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
@@ -72,24 +73,8 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForU [
 
 { #category : #tests }
 SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForV [
-	"We compute a matrix of signs for V with which
-	we perform a 'dot product' with the original
-	matrix V
-	(by 'dot product' we mean send the dot: message)
-	Example here is taken from Scikit Learn
-	
-	U = [[-0.21956688  0.53396977]
- 		 [-0.35264795 -0.45713538]
- 		 [-0.57221483  0.07683439]
- 		 [ 0.21956688 -0.53396977]
- 	    [ 0.35264795  0.45713538]
- 	    [ 0.57221483 -0.07683439]]
-
-   V = [[ 0.83849224  0.54491354]
- 		 [ 0.54491354 -0.83849224]]    
-	"
-
 	| signAlgo expected |
+	
 	self setUpScikitLearnExample .
 	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
 	
@@ -99,21 +84,8 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForV [
 
 { #category : #tests }
 SciKitLearnEigenvectorFlipAlgorithmTest >> testUFlipped [
-	"Here we calculate the U matrix with its signs flipped 
-	Example here is taken from Scikit Learn
-	
-	U = [[-0.21956688  0.53396977]
- 		 [-0.35264795 -0.45713538]
- 		 [-0.57221483  0.07683439]
- 		 [ 0.21956688 -0.53396977]
- 	    [ 0.35264795  0.45713538]
- 	    [ 0.57221483 -0.07683439]]
-
-   V = [[ 0.83849224  0.54491354]
- 		 [ 0.54491354 -0.83849224]]    
-	"
-
 	| signAlgo expected |
+	
 	self setUpScikitLearnExample .
 	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
 	
@@ -132,21 +104,8 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testUFlipped [
 
 { #category : #tests }
 SciKitLearnEigenvectorFlipAlgorithmTest >> testVFlipped [
-	"Here we calculate the U matrix with its signs flipped 
-	Example here is taken from Scikit Learn
-	
-	U = [[-0.21956688  0.53396977]
- 		 [-0.35264795 -0.45713538]
- 		 [-0.57221483  0.07683439]
- 		 [ 0.21956688 -0.53396977]
- 	    [ 0.35264795  0.45713538]
- 	    [ 0.57221483 -0.07683439]]
-
-   V = [[ 0.83849224  0.54491354]
- 		 [ 0.54491354 -0.83849224]]    
-	"
-
 	| signAlgo expected |
+	
 	self setUpScikitLearnExample .
 	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
 	

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -52,7 +52,7 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
 
 	| flipAlgorithm expected signs |
 	self setUpScikitLearnExample .
-	flipAlgorithm := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
+	flipAlgorithm := SciKitLearnEigenvectorFlipAlgorithm flipU: u andV: v.
 	
 	signs := flipAlgorithm computeSignsFromU .
 	
@@ -64,7 +64,7 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
 SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForU [
 	| signAlgo expected |
 	self setUpScikitLearnExample .
-	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
+	signAlgo := SciKitLearnEigenvectorFlipAlgorithm flipU: u andV: v.
 	
 	expected := PMMatrix rows: #(#(-1 1) #(-1 1) #(-1 1) #(-1 1) #(-1 1) #(-1 1)).
 	self assert: (signAlgo signMatrixForU) equals: expected
@@ -76,7 +76,7 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForV [
 	| signAlgo expected |
 	
 	self setUpScikitLearnExample .
-	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
+	signAlgo := SciKitLearnEigenvectorFlipAlgorithm flipU: u andV: v.
 	
 	expected := PMMatrix rows: #(#(-1 -1) #(1 1)).
 	self assert: (signAlgo signMatrixForV) equals: expected
@@ -87,7 +87,7 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testUFlipped [
 	| signAlgo expected |
 	
 	self setUpScikitLearnExample .
-	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
+	signAlgo := SciKitLearnEigenvectorFlipAlgorithm flipU: u andV: v.
 	
 	expected := PMMatrix rows: #(
 						#(0.21956688  0.53396977)
@@ -107,7 +107,7 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testVFlipped [
 	| signAlgo expected |
 	
 	self setUpScikitLearnExample .
-	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
+	signAlgo := SciKitLearnEigenvectorFlipAlgorithm flipU: u andV: v.
 	
 	expected := PMMatrix rows: #(
 					 #(-0.83849224 -0.54491354)

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -57,10 +57,8 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForV [
 	v := PMMatrix rows: #(
 		#(0.83849224  0.54491354) 
 		#(0.54491354 -0.83849224)).
-	signs := #(-1 1 1 1 1 1) asPMVector .
 	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
 	
-	
 	expected := PMMatrix rows: #(#(-1 1) #(-1 1)).
-	self assert: (signAlgo signMatrixForV: signs) equals: expected
+	self assert: (signAlgo signMatrixForV) equals: expected
 ]

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -21,7 +21,7 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testFlipEigenvectorsSign [
 	v := svd rightSingularForm.
 	flipAlgorithm := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
 	
-	signs := flipAlgorithm computeSigns .
+	signs := flipAlgorithm computeSignsFromU .
 	
 	expected := #(-1 -1 -1 1 1 -1) asPMVector.
 	self assert: signs equals: expected

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -29,7 +29,7 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
 
 { #category : #tests }
 SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForU [
-	"We compute a matrix of signs for U with which
+	"We compute a matrix of signs for u with which
 	we perform a 'dot product' with the original
 	matrix V
 	(by 'dot product' we mean send the dot: message)
@@ -98,4 +98,46 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForV [
 	
 	expected := PMMatrix rows: #(#(-1 1) #(-1 1)).
 	self assert: (signAlgo signMatrixForV) equals: expected
+]
+
+{ #category : #tests }
+SciKitLearnEigenvectorFlipAlgorithmTest >> testUFlipped [
+	"Here we calculate the U matrix with its signs flipped 
+	Example here is taken from Scikit Learn
+	
+	U = [[-0.21956688  0.53396977]
+ 		 [-0.35264795 -0.45713538]
+ 		 [-0.57221483  0.07683439]
+ 		 [ 0.21956688 -0.53396977]
+ 	    [ 0.35264795  0.45713538]
+ 	    [ 0.57221483 -0.07683439]]
+
+   V = [[ 0.83849224  0.54491354]
+ 		 [ 0.54491354 -0.83849224]]    
+	"
+
+	| u v signAlgo expected |
+	u := PMMatrix rows: #(
+		#(-0.21956688 0.53396977) 
+		#(-0.35264795 -0.45713538) 
+		#(-0.57221483  0.07683439) 
+		#( 0.21956688 -0.53396977) 
+		#( 0.35264795  0.45713538) 
+		#( 0.57221483 -0.07683439)).
+	v := PMMatrix rows: #(
+		#(0.83849224  0.54491354) 
+		#(0.54491354 -0.83849224)).
+	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
+	
+	expected := PMMatrix rows: #(
+						#(0.21956688  0.53396977)
+   						#(0.35264795 -0.45713538)
+   						#(0.57221483  0.07683439)
+ 						#(-0.21956688 -0.53396977)
+ 						#(-0.35264795  0.45713538)
+ 						#(-0.57221483 -0.07683439)).
+
+	self assert: (signAlgo uFlipped) equals: expected
+
+	
 ]

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -83,7 +83,7 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForV [
  		 [ 0.54491354 -0.83849224]]    
 	"
 
-	| u v signAlgo signs expected |
+	| u v signAlgo expected |
 	u := PMMatrix rows: #(
 		#(-0.21956688 0.53396977) 
 		#(-0.35264795 -0.45713538) 

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -29,7 +29,7 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
 
 { #category : #tests }
 SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForU [
-	"We compute a matrix of signs for V with which
+	"We compute a matrix of signs for U with which
 	we perform a 'dot product' with the original
 	matrix V
 	(by 'dot product' we mean send the dot: message)

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -28,6 +28,43 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
 ]
 
 { #category : #tests }
+SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForU [
+	"We compute a matrix of signs for V with which
+	we perform a 'dot product' with the original
+	matrix V
+	(by 'dot product' we mean send the dot: message)
+	Example here is taken from Scikit Learn
+	
+	U = [[-0.21956688  0.53396977]
+ 		 [-0.35264795 -0.45713538]
+ 		 [-0.57221483  0.07683439]
+ 		 [ 0.21956688 -0.53396977]
+ 	    [ 0.35264795  0.45713538]
+ 	    [ 0.57221483 -0.07683439]]
+
+   V = [[ 0.83849224  0.54491354]
+ 		 [ 0.54491354 -0.83849224]]    
+	"
+
+	| u v signAlgo expected |
+	u := PMMatrix rows: #(
+		#(-0.21956688 0.53396977) 
+		#(-0.35264795 -0.45713538) 
+		#(-0.57221483  0.07683439) 
+		#( 0.21956688 -0.53396977) 
+		#( 0.35264795  0.45713538) 
+		#( 0.57221483 -0.07683439)).
+	v := PMMatrix rows: #(
+		#(0.83849224  0.54491354) 
+		#(0.54491354 -0.83849224)).
+	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
+	
+	expected := PMMatrix rows: #(#(-1 1) #(-1 1) #(-1 1) #(-1 1) #(-1 1) #(-1 1)).
+	self assert: (signAlgo signMatrixForU) equals: expected
+
+]
+
+{ #category : #tests }
 SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForV [
 	"We compute a matrix of signs for V with which
 	we perform a 'dot product' with the original

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -1,0 +1,28 @@
+"
+This is the test class that exercises scikit-learn Eigenvector Flip Algorithm
+
+"
+Class {
+	#name : #SciKitLearnEigenvectorFlipAlgorithmTest,
+	#superclass : #TestCase,
+	#category : #'Math-Tests-PrincipalComponentAnalysis'
+}
+
+{ #category : #tests }
+SciKitLearnEigenvectorFlipAlgorithmTest >> testFlipEigenvectorsSign [
+	"The purpose is to compare the output from fligEigenVectorsSign in
+	PolyMath with scikit-learn
+	"
+
+	| m u v flipAlgorithm svd expected signs |
+	m := PMMatrix rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
+	svd := PMSingularValueDecomposition new initialize: m.
+	u := svd leftSingularForm.
+	v := svd rightSingularForm.
+	flipAlgorithm := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
+	
+	signs := flipAlgorithm computeSigns .
+	
+	expected := #(-1 -1 -1 1 1 -1) asPMVector.
+	self assert: signs equals: expected
+]

--- a/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/SciKitLearnEigenvectorFlipAlgorithmTest.class.st
@@ -5,8 +5,26 @@ This is the test class that exercises scikit-learn Eigenvector Flip Algorithm
 Class {
 	#name : #SciKitLearnEigenvectorFlipAlgorithmTest,
 	#superclass : #TestCase,
+	#instVars : [
+		'u',
+		'v'
+	],
 	#category : #'Math-Tests-PrincipalComponentAnalysis'
 }
+
+{ #category : #initialization }
+SciKitLearnEigenvectorFlipAlgorithmTest >> setUpScikitLearnExample [
+	u := PMMatrix rows: #(
+		#(-0.21956688 0.53396977) 
+		#(-0.35264795 -0.45713538) 
+		#(-0.57221483  0.07683439) 
+		#( 0.21956688 -0.53396977) 
+		#( 0.35264795  0.45713538) 
+		#( 0.57221483 -0.07683439)).
+	v := PMMatrix rows: #(
+		#(0.83849224  0.54491354) 
+		#(0.54491354 -0.83849224)).
+]
 
 { #category : #tests }
 SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
@@ -46,17 +64,8 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForU [
  		 [ 0.54491354 -0.83849224]]    
 	"
 
-	| u v signAlgo expected |
-	u := PMMatrix rows: #(
-		#(-0.21956688 0.53396977) 
-		#(-0.35264795 -0.45713538) 
-		#(-0.57221483  0.07683439) 
-		#( 0.21956688 -0.53396977) 
-		#( 0.35264795  0.45713538) 
-		#( 0.57221483 -0.07683439)).
-	v := PMMatrix rows: #(
-		#(0.83849224  0.54491354) 
-		#(0.54491354 -0.83849224)).
+	| signAlgo expected |
+	self setUpScikitLearnExample .
 	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
 	
 	expected := PMMatrix rows: #(#(-1 1) #(-1 1) #(-1 1) #(-1 1) #(-1 1) #(-1 1)).
@@ -83,17 +92,8 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForV [
  		 [ 0.54491354 -0.83849224]]    
 	"
 
-	| u v signAlgo expected |
-	u := PMMatrix rows: #(
-		#(-0.21956688 0.53396977) 
-		#(-0.35264795 -0.45713538) 
-		#(-0.57221483  0.07683439) 
-		#( 0.21956688 -0.53396977) 
-		#( 0.35264795  0.45713538) 
-		#( 0.57221483 -0.07683439)).
-	v := PMMatrix rows: #(
-		#(0.83849224  0.54491354) 
-		#(0.54491354 -0.83849224)).
+	| signAlgo expected |
+	self setUpScikitLearnExample .
 	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
 	
 	expected := PMMatrix rows: #(#(-1 -1) #(1 1)).
@@ -116,17 +116,8 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testUFlipped [
  		 [ 0.54491354 -0.83849224]]    
 	"
 
-	| u v signAlgo expected |
-	u := PMMatrix rows: #(
-		#(-0.21956688 0.53396977) 
-		#(-0.35264795 -0.45713538) 
-		#(-0.57221483  0.07683439) 
-		#( 0.21956688 -0.53396977) 
-		#( 0.35264795  0.45713538) 
-		#( 0.57221483 -0.07683439)).
-	v := PMMatrix rows: #(
-		#(0.83849224  0.54491354) 
-		#(0.54491354 -0.83849224)).
+	| signAlgo expected |
+	self setUpScikitLearnExample .
 	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
 	
 	expected := PMMatrix rows: #(
@@ -158,17 +149,8 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testVFlipped [
  		 [ 0.54491354 -0.83849224]]    
 	"
 
-	| u v signAlgo expected |
-	u := PMMatrix rows: #(
-		#(-0.21956688 0.53396977) 
-		#(-0.35264795 -0.45713538) 
-		#(-0.57221483  0.07683439) 
-		#( 0.21956688 -0.53396977) 
-		#( 0.35264795  0.45713538) 
-		#( 0.57221483 -0.07683439)).
-	v := PMMatrix rows: #(
-		#(0.83849224  0.54491354) 
-		#(0.54491354 -0.83849224)).
+	| signAlgo expected |
+	self setUpScikitLearnExample .
 	signAlgo := SciKitLearnEigenvectorFlipAlgorithm u: u v: v.
 	
 	expected := PMMatrix rows: #(


### PR DESCRIPTION
This PR has got the scikit-learn based sign flipping algorithm working. We started by extracting a class that, given U and V, performs the sign flipping. As an acceptance test, we used the U and V matrices computed by scikit-learn. 

In the course of this work we found that for the SVD-based implementation of PCA, the V matrix in PolyMath does not match scikit learn's in terms of the signs; the magnitudes of the elements match though (see comments in #81). As a cross-check we used Wolfram Alpha to perform the same decomposition. Interestingly that does match the matrix yielded by PolyMath. We also checked that 

V<sup>-1</sup>M<sup>T</sup>MV 

yields a diagonalised matrix, which it did.