### PR TITLE
[issue-81] Name of the class now conforms to the PolyMath codestyle.

### DIFF
--- a/src/Math-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserSVD.class.st
+++ b/src/Math-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserSVD.class.st
@@ -50,7 +50,7 @@ PMPrincipalComponentAnalyserSVD >> flipEigenvectorsSign [
 	"U-based decision like : https://github.com/scikit-learn/scikit-learn/blob/4c65d8e615c9331d37cbb6225c5b67c445a5c959/sklearn/utils/extmath.py#L609"
 	
 	| algo |
-	algo := SciKitLearnEigenvectorFlipAlgorithm flipU: u andV: v.
+	algo := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
 	
 	u := algo uFlipped . 
 	v := algo vFlipped . 

--- a/src/Math-PrincipalComponentAnalysis/PMSciKitLearnSVDFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/PMSciKitLearnSVDFlipAlgorithm.class.st
@@ -6,7 +6,7 @@ This class uses the SciKit-Learn SVD flip algorithm to ensure the signs of the e
 
 "
 Class {
-	#name : #SciKitLearnEigenvectorFlipAlgorithm,
+	#name : #PMSciKitLearnSVDFlipAlgorithm,
 	#superclass : #Object,
 	#instVars : [
 		'u',
@@ -17,14 +17,14 @@ Class {
 }
 
 { #category : #'instance creation' }
-SciKitLearnEigenvectorFlipAlgorithm class >> flipU: u andV: v [
+PMSciKitLearnSVDFlipAlgorithm class >> flipU: u andV: v [
 	^ self new
 		initializeWithU: u andV: v;
 		yourself
 ]
 
 { #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> computeSignsFromU [
+PMSciKitLearnSVDFlipAlgorithm >> computeSignsFromU [
 	| maxAbsCols i maxElements |
 	maxAbsCols := u abs argMaxOnColumns.
 	i := 0.
@@ -36,7 +36,7 @@ SciKitLearnEigenvectorFlipAlgorithm >> computeSignsFromU [
 ]
 
 { #category : #initialization }
-SciKitLearnEigenvectorFlipAlgorithm >> initializeWithU: uMatrix andV: vMatrix [
+PMSciKitLearnSVDFlipAlgorithm >> initializeWithU: uMatrix andV: vMatrix [
 	"instantiate the algorithm"
 	u := uMatrix .
 	v := vMatrix .
@@ -46,7 +46,7 @@ SciKitLearnEigenvectorFlipAlgorithm >> initializeWithU: uMatrix andV: vMatrix [
 ]
 
 { #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> signMatrixForU [
+PMSciKitLearnSVDFlipAlgorithm >> signMatrixForU [
 	^ PMMatrix
 		rows:
 			((1 to: u numberOfRows)
@@ -58,7 +58,7 @@ SciKitLearnEigenvectorFlipAlgorithm >> signMatrixForU [
 ]
 
 { #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> signMatrixForV [
+PMSciKitLearnSVDFlipAlgorithm >> signMatrixForV [
 	| signsForV |
 	signsForV := self signs copyFrom: 1 to: v numberOfColumns.
 	^ (PMMatrix
@@ -72,16 +72,16 @@ SciKitLearnEigenvectorFlipAlgorithm >> signMatrixForV [
 ]
 
 { #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> signs [
+PMSciKitLearnSVDFlipAlgorithm >> signs [
 	^ signs
 ]
 
 { #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> uFlipped [
+PMSciKitLearnSVDFlipAlgorithm >> uFlipped [
 	^ u dot: (self signMatrixForU).
 ]
 
 { #category : #accessing }
-SciKitLearnEigenvectorFlipAlgorithm >> vFlipped [
+PMSciKitLearnSVDFlipAlgorithm >> vFlipped [
 	^ v dot: (self signMatrixForV) .
 ]

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMSciKitLearnSVDFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMSciKitLearnSVDFlipAlgorithmTest.class.st
@@ -3,7 +3,7 @@ This is the test class that exercises scikit-learn Eigenvector Flip Algorithm
 
 "
 Class {
-	#name : #SciKitLearnEigenvectorFlipAlgorithmTest,
+	#name : #PMSciKitLearnSVDFlipAlgorithmTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'u',
@@ -13,7 +13,7 @@ Class {
 }
 
 { #category : #initialization }
-SciKitLearnEigenvectorFlipAlgorithmTest >> setUpScikitLearnExample [
+PMSciKitLearnSVDFlipAlgorithmTest >> setUpScikitLearnExample [
 "  We compute a matrix of signs for U with which
 	we perform a 'dot product' with the original
 	matrix V
@@ -45,14 +45,14 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> setUpScikitLearnExample [
 ]
 
 { #category : #tests }
-SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
+PMSciKitLearnSVDFlipAlgorithmTest >> testComputeSignsFromU [
 	"The purpose is to compare the output from fligEigenVectorsSign in
 	PolyMath with scikit-learn
 	"
 
 	| flipAlgorithm expected signs |
 	self setUpScikitLearnExample .
-	flipAlgorithm := SciKitLearnEigenvectorFlipAlgorithm flipU: u andV: v.
+	flipAlgorithm := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
 	
 	signs := flipAlgorithm computeSignsFromU .
 	
@@ -61,10 +61,10 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testComputeSignsFromU [
 ]
 
 { #category : #tests }
-SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForU [
+PMSciKitLearnSVDFlipAlgorithmTest >> testSignMatrixForU [
 	| signAlgo expected |
 	self setUpScikitLearnExample .
-	signAlgo := SciKitLearnEigenvectorFlipAlgorithm flipU: u andV: v.
+	signAlgo := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
 	
 	expected := PMMatrix rows: #(#(-1 1) #(-1 1) #(-1 1) #(-1 1) #(-1 1) #(-1 1)).
 	self assert: (signAlgo signMatrixForU) equals: expected
@@ -72,22 +72,22 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForU [
 ]
 
 { #category : #tests }
-SciKitLearnEigenvectorFlipAlgorithmTest >> testSignMatrixForV [
+PMSciKitLearnSVDFlipAlgorithmTest >> testSignMatrixForV [
 	| signAlgo expected |
 	
 	self setUpScikitLearnExample .
-	signAlgo := SciKitLearnEigenvectorFlipAlgorithm flipU: u andV: v.
+	signAlgo := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
 	
 	expected := PMMatrix rows: #(#(-1 -1) #(1 1)).
 	self assert: (signAlgo signMatrixForV) equals: expected
 ]
 
 { #category : #tests }
-SciKitLearnEigenvectorFlipAlgorithmTest >> testUFlipped [
+PMSciKitLearnSVDFlipAlgorithmTest >> testUFlipped [
 	| signAlgo expected |
 	
 	self setUpScikitLearnExample .
-	signAlgo := SciKitLearnEigenvectorFlipAlgorithm flipU: u andV: v.
+	signAlgo := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
 	
 	expected := PMMatrix rows: #(
 						#(0.21956688  0.53396977)
@@ -103,11 +103,11 @@ SciKitLearnEigenvectorFlipAlgorithmTest >> testUFlipped [
 ]
 
 { #category : #tests }
-SciKitLearnEigenvectorFlipAlgorithmTest >> testVFlipped [
+PMSciKitLearnSVDFlipAlgorithmTest >> testVFlipped [
 	| signAlgo expected |
 	
 	self setUpScikitLearnExample .
-	signAlgo := SciKitLearnEigenvectorFlipAlgorithm flipU: u andV: v.
+	signAlgo := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
 	
 	expected := PMMatrix rows: #(
 					 #(-0.83849224 -0.54491354)


### PR DESCRIPTION
Classes in PolyMath should be prefixed with `PM`. This PR contains the change for this. Along the way I improved the name of the class a bit.