### PR TITLE
[Issue 81] - 2 PCA implementations that give same results but different from Python scikit-learn implementation

### DIFF
--- a/src/Math-Core/PMVector.class.st
+++ b/src/Math-Core/PMVector.class.st
@@ -115,16 +115,8 @@ PMVector >> accumulateNegated: aVectorOrAnArray [
 
 { #category : #'as yet unclassified' }
 PMVector >> argMax [
-	| precision |
-	precision := 1.0e-10.
-	^ self argMaxTo: precision
-]
-
-{ #category : #'as yet unclassified' }
-PMVector >> argMaxTo: roundingPrecision [
 	| a |
-	a := self asArray
-		collect: [ :element | element truncateTo: roundingPrecision ].
+	a := self asArray.
 	^ a indexOf: a max
 ]
 

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
@@ -18,7 +18,7 @@ PMPrincipalComponentAnalyserTest >> testPCAwithPCAandJacobiTransformationReturnS
 	pca1 fit: m.
 	pca2 := PMPrincipalComponentAnalyserJacobiTransformation new componentsNumber: 2.
 	pca2 fit: m.
-	self assert: pca1 transformMatrix closeTo: pca2 transformMatrix
+	self assert: pca1 transformMatrix abs closeTo: pca2 transformMatrix abs
 ]
 
 { #category : #tests }
@@ -27,7 +27,7 @@ PMPrincipalComponentAnalyserTest >> testTransformMatrixWithJacobiTransformation 
 	m := PMMatrix rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
 	pca := PMPrincipalComponentAnalyserJacobiTransformation new componentsNumber: 2.
 	pca fit: m.
-	self assert: pca transformMatrix closeTo: (PMMatrix rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224)))
+	self assert: pca transformMatrix abs closeTo: (PMMatrix rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224))) abs
 ]
 
 { #category : #tests }
@@ -36,5 +36,5 @@ PMPrincipalComponentAnalyserTest >> testTransformMatrixWithSVD [
 	m := PMMatrix rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
 	pca := PMPrincipalComponentAnalyserSVD new componentsNumber: 2.
 	pca fit: m.
-	self assert: pca transformMatrix closeTo: (PMMatrix rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224)))
+	self assert: pca transformMatrix abs closeTo: (PMMatrix rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224))) abs
 ]

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
@@ -18,23 +18,35 @@ PMPrincipalComponentAnalyserTest >> testPCAwithPCAandJacobiTransformationReturnS
 	pca1 fit: m.
 	pca2 := PMPrincipalComponentAnalyserJacobiTransformation new componentsNumber: 2.
 	pca2 fit: m.
+	
 	self assert: pca1 transformMatrix abs closeTo: pca2 transformMatrix abs
 ]
 
 { #category : #tests }
 PMPrincipalComponentAnalyserTest >> testTransformMatrixWithJacobiTransformation [
-	| m pca |
-	m := PMMatrix rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
-	pca := PMPrincipalComponentAnalyserJacobiTransformation new componentsNumber: 2.
+	| m pca expected |
+	m := PMMatrix
+		rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
+	pca := PMPrincipalComponentAnalyserJacobiTransformation new
+		componentsNumber: 2.
+	
 	pca fit: m.
-	self assert: pca transformMatrix abs closeTo: (PMMatrix rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224))) abs
+	
+	expected := (PMMatrix
+		rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224))) abs.
+	self assert: pca transformMatrix abs closeTo: expected
 ]
 
 { #category : #tests }
 PMPrincipalComponentAnalyserTest >> testTransformMatrixWithSVD [
-	| m pca |
-	m := PMMatrix rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
+	| m pca expected |
+	m := PMMatrix
+		rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
 	pca := PMPrincipalComponentAnalyserSVD new componentsNumber: 2.
+	
 	pca fit: m.
-	self assert: pca transformMatrix abs closeTo: (PMMatrix rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224))) abs
+	
+	expected := (PMMatrix
+		rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224))) abs.
+	self assert: pca transformMatrix abs closeTo: expected
 ]

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMSciKitLearnSVDFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMSciKitLearnSVDFlipAlgorithmTest.class.st
@@ -14,7 +14,7 @@ Class {
 }
 
 { #category : #initialization }
-PMSciKitLearnSVDFlipAlgorithmTest >> setUpScikitLearnExample [
+PMSciKitLearnSVDFlipAlgorithmTest >> setUp [
 "  We compute a matrix of signs for U with which
 	we perform a 'dot product' with the original
 	matrix V
@@ -54,8 +54,7 @@ PMSciKitLearnSVDFlipAlgorithmTest >> testComputeSignsFromU [
 	"
 
 	| expected signs |
-	self setUpScikitLearnExample.
-
+	
 	signs := flipAlgorithm computeSignsFromU.
 
 	expected := #(-1 1) asPMVector.
@@ -65,9 +64,8 @@ PMSciKitLearnSVDFlipAlgorithmTest >> testComputeSignsFromU [
 { #category : #'scikit-learn-example' }
 PMSciKitLearnSVDFlipAlgorithmTest >> testSignMatrixForU [
 	| expected |
-	self setUpScikitLearnExample .
-	
 	expected := PMMatrix rows: #(#(-1 1) #(-1 1) #(-1 1) #(-1 1) #(-1 1) #(-1 1)).
+	
 	self assert: (flipAlgorithm signMatrixForU) equals: expected
 
 ]
@@ -75,17 +73,14 @@ PMSciKitLearnSVDFlipAlgorithmTest >> testSignMatrixForU [
 { #category : #'scikit-learn-example' }
 PMSciKitLearnSVDFlipAlgorithmTest >> testSignMatrixForV [
 	| expected |
-	self setUpScikitLearnExample .
-	
 	expected := PMMatrix rows: #(#(-1 -1) #(1 1)).
+	
 	self assert: (flipAlgorithm signMatrixForV) equals: expected
 ]
 
 { #category : #'scikit-learn-example' }
 PMSciKitLearnSVDFlipAlgorithmTest >> testUFlipped [
 	| expected |
-	self setUpScikitLearnExample .
-	
 	expected := PMMatrix rows: #(
 						#(0.21956688  0.53396977)
    						#(0.35264795 -0.45713538)
@@ -102,8 +97,6 @@ PMSciKitLearnSVDFlipAlgorithmTest >> testUFlipped [
 { #category : #'scikit-learn-example' }
 PMSciKitLearnSVDFlipAlgorithmTest >> testVFlipped [
 	| expected |
-	self setUpScikitLearnExample.
-
 	expected := PMMatrix rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224)).
 
 	self assert: flipAlgorithm vFlipped equals: expected

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMSciKitLearnSVDFlipAlgorithmTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMSciKitLearnSVDFlipAlgorithmTest.class.st
@@ -7,7 +7,8 @@ Class {
 	#superclass : #TestCase,
 	#instVars : [
 		'u',
-		'v'
+		'v',
+		'flipAlgorithm'
 	],
 	#category : #'Math-Tests-PrincipalComponentAnalysis'
 }
@@ -42,52 +43,48 @@ PMSciKitLearnSVDFlipAlgorithmTest >> setUpScikitLearnExample [
 	v := PMMatrix rows: #(
 		#(0.83849224  0.54491354) 
 		#(0.54491354 -0.83849224)).
+		
+	flipAlgorithm := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
 ]
 
-{ #category : #tests }
+{ #category : #'scikit-learn-example' }
 PMSciKitLearnSVDFlipAlgorithmTest >> testComputeSignsFromU [
 	"The purpose is to compare the output from fligEigenVectorsSign in
 	PolyMath with scikit-learn
 	"
 
-	| flipAlgorithm expected signs |
-	self setUpScikitLearnExample .
-	flipAlgorithm := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
-	
-	signs := flipAlgorithm computeSignsFromU .
-	
-	expected := #(-1 1) asPMVector .
+	| expected signs |
+	self setUpScikitLearnExample.
+
+	signs := flipAlgorithm computeSignsFromU.
+
+	expected := #(-1 1) asPMVector.
 	self assert: signs equals: expected
 ]
 
-{ #category : #tests }
+{ #category : #'scikit-learn-example' }
 PMSciKitLearnSVDFlipAlgorithmTest >> testSignMatrixForU [
-	| signAlgo expected |
+	| expected |
 	self setUpScikitLearnExample .
-	signAlgo := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
 	
 	expected := PMMatrix rows: #(#(-1 1) #(-1 1) #(-1 1) #(-1 1) #(-1 1) #(-1 1)).
-	self assert: (signAlgo signMatrixForU) equals: expected
+	self assert: (flipAlgorithm signMatrixForU) equals: expected
 
 ]
 
-{ #category : #tests }
+{ #category : #'scikit-learn-example' }
 PMSciKitLearnSVDFlipAlgorithmTest >> testSignMatrixForV [
-	| signAlgo expected |
-	
+	| expected |
 	self setUpScikitLearnExample .
-	signAlgo := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
 	
 	expected := PMMatrix rows: #(#(-1 -1) #(1 1)).
-	self assert: (signAlgo signMatrixForV) equals: expected
+	self assert: (flipAlgorithm signMatrixForV) equals: expected
 ]
 
-{ #category : #tests }
+{ #category : #'scikit-learn-example' }
 PMSciKitLearnSVDFlipAlgorithmTest >> testUFlipped [
-	| signAlgo expected |
-	
+	| expected |
 	self setUpScikitLearnExample .
-	signAlgo := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
 	
 	expected := PMMatrix rows: #(
 						#(0.21956688  0.53396977)
@@ -97,23 +94,17 @@ PMSciKitLearnSVDFlipAlgorithmTest >> testUFlipped [
  						#(-0.35264795  0.45713538)
  						#(-0.57221483 -0.07683439)).
 
-	self assert: (signAlgo uFlipped) equals: expected
+	self assert: (flipAlgorithm uFlipped) equals: expected
 
 	
 ]
 
-{ #category : #tests }
+{ #category : #'scikit-learn-example' }
 PMSciKitLearnSVDFlipAlgorithmTest >> testVFlipped [
-	| signAlgo expected |
-	
-	self setUpScikitLearnExample .
-	signAlgo := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
-	
-	expected := PMMatrix rows: #(
-					 #(-0.83849224 -0.54491354)
- 					 #(0.54491354 -0.83849224)).
+	| expected |
+	self setUpScikitLearnExample.
 
-	self assert: (signAlgo vFlipped) equals: expected
+	expected := PMMatrix rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224)).
 
-	
+	self assert: flipAlgorithm vFlipped equals: expected
 ]

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMScikitLearnSVDFlipAlgorithmSandiaTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMScikitLearnSVDFlipAlgorithmSandiaTest.class.st
@@ -62,3 +62,27 @@ PMScikitLearnSVDFlipAlgorithmSandiaTest >> testSignMatrixForV [
 	
 	self assert: flipAlgorithm signMatrixForV equals: expected
 ]
+
+{ #category : #'sandia-example' }
+PMScikitLearnSVDFlipAlgorithmSandiaTest >> testUFlipped [
+	| expected |
+	expected := PMMatrix rows: #(
+			#(3.37888092e-01 7.97390517e-01 5.00000000e-01 7.29361893e-17) 
+			#(6.39157626e-01 -5.84360787e-01 5.00000000e-01 6.37482349e-17) 
+			#(-4.88522859e-01 -1.06514865e-01 5.00000000e-01 7.07106781e-01) 
+			#(-4.88522859e-01 -1.06514865e-01 5.00000000e-01 -7.07106781e-01)).
+			
+	self assert: flipAlgorithm uFlipped equals: expected
+]
+
+{ #category : #'sandia-example' }
+PMScikitLearnSVDFlipAlgorithmSandiaTest >> testVFlipped [
+	| expected |
+	expected := PMMatrix rows: #(
+			#(-0.1480984 -0.96040168 -0.13728871 -0.19195647) 
+			#(0.43936626 -0.13130934 -0.54106008 0.70496038) 
+			#(0.42589859 -0.24444267 0.8129595 0.31297767) 
+			#(0.77693921 0.02518437 -0.16583923 -0.60681839)).
+	
+	self assert: flipAlgorithm vFlipped equals: expected
+]

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMScikitLearnSVDFlipAlgorithmSandiaTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMScikitLearnSVDFlipAlgorithmSandiaTest.class.st
@@ -42,8 +42,7 @@ PMScikitLearnSVDFlipAlgorithmSandiaTest >> setUp [
 { #category : #'sandia-example' }
 PMScikitLearnSVDFlipAlgorithmSandiaTest >> testSignMatrixForU [
 	| expected |
-	self setUp.
-
+	
 	expected := PMMatrix
 		rows:
 			#(#(-1 1 -1 -1) #(-1 1 -1 -1) #(-1 1 -1 -1) #(-1 1 -1 -1)).
@@ -54,8 +53,6 @@ PMScikitLearnSVDFlipAlgorithmSandiaTest >> testSignMatrixForU [
 { #category : #'sandia-example' }
 PMScikitLearnSVDFlipAlgorithmSandiaTest >> testSignMatrixForV [
 	| expected |
-	self setUp.
-
 	expected := PMMatrix
 		rows:
 			#(#(-1 -1 -1 -1) #(1 1 1 1) #(-1 -1 -1 -1) #(-1 -1 -1 -1)).

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMScikitLearnSVDFlipAlgorithmSandiaTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMScikitLearnSVDFlipAlgorithmSandiaTest.class.st
@@ -1,0 +1,64 @@
+"
+These tests use the example from:
+https://prod-ng.sandia.gov/techlib-noauth/access-control.cgi/2007/076422.pdf
+
+X =  [  4  22   3    5]
+        [  1    5    1   1]
+        [11 69 10 14]
+        [11 69 10 14]
+
+The expected output is the computation carried out by Scikit-Learn's SVD flip algorithm.
+"
+Class {
+	#name : #PMScikitLearnSVDFlipAlgorithmSandiaTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'u',
+		'v',
+		'flipAlgorithm'
+	],
+	#category : #'Math-Tests-PrincipalComponentAnalysis'
+}
+
+{ #category : #initialization }
+PMScikitLearnSVDFlipAlgorithmSandiaTest >> setUp [
+	u:= PMMatrix rows: #(
+	 		 #(-3.37888092e-01  7.97390517e-01 -5.00000000e-01 -7.29361893e-17)
+ 			 #(-6.39157626e-01 -5.84360787e-01 -5.00000000e-01 -6.37482349e-17)
+ 			 #(4.88522859e-01 -1.06514865e-01 -5.00000000e-01 -7.07106781e-01)
+ 			 #(4.88522859e-01 -1.06514865e-01 -5.00000000e-01  7.07106781e-01)
+		).
+	
+	v := PMMatrix rows: #(
+  			 #(0.1480984   0.96040168  0.13728871  0.19195647)
+ 			 #(0.43936626 -0.13130934 -0.54106008  0.70496038)
+ 			 #(-0.42589859  0.24444267 -0.8129595  -0.31297767)
+ 			 #(-0.77693921 -0.02518437  0.16583923  0.60681839)
+		  ).
+	
+	flipAlgorithm := PMSciKitLearnSVDFlipAlgorithm flipU: u andV: v.
+]
+
+{ #category : #'sandia-example' }
+PMScikitLearnSVDFlipAlgorithmSandiaTest >> testSignMatrixForU [
+	| expected |
+	self setUp.
+
+	expected := PMMatrix
+		rows:
+			#(#(-1 1 -1 -1) #(-1 1 -1 -1) #(-1 1 -1 -1) #(-1 1 -1 -1)).
+
+	self assert: flipAlgorithm signMatrixForU equals: expected
+]
+
+{ #category : #'sandia-example' }
+PMScikitLearnSVDFlipAlgorithmSandiaTest >> testSignMatrixForV [
+	| expected |
+	self setUp.
+
+	expected := PMMatrix
+		rows:
+			#(#(-1 -1 -1 -1) #(1 1 1 1) #(-1 -1 -1 -1) #(-1 -1 -1 -1)).
+	
+	self assert: flipAlgorithm signMatrixForV equals: expected
+]


### PR DESCRIPTION
This PR relates issue #81 

I used Scikit-Learn to decompose a matrix from a [Sandia National Lab paper](https://www.researchgate.net/publication/227677444_Resolving_the_sign_ambiguity_in_the_singular_value_decomposition) on SVD sign ambiguity. The U and V from this computation were used as 'triangulation' tests.

I mobbed with @olekscode and @SergeStinckwich and we decided that for the PCA tests we could check that the moduli of the matrix elements were close enough.