### PR TITLE
[Issue 81] 2 PCA implementations that give same results but different from Python scikit-learn implementation

### DIFF
--- a/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
@@ -50,3 +50,39 @@ PMPrincipalComponentAnalyserTest >> testTransformMatrixWithSVD [
 		rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224))) abs.
 	self assert: pca transformMatrix abs closeTo: expected
 ]
+
+{ #category : #'pca tutorial' }
+PMPrincipalComponentAnalyserTest >> testTransformWithMeanCentredMeasurements [
+	"As acceptance tests we use the worked example of the PCA tutorial of Lindsay Smith"
+
+	| m pca transformedData expected |
+	m := PMMatrix rows: #(
+			#(0.69 0.49) 
+			#(-1.31 -1.21) 
+			#(0.39 0.99) 
+			#(0.09  0.29) 
+			#(1.29 1.09) 
+			#(0.49 0.79) 
+			#(0.19 -0.31) 
+			#(-0.81 -0.81) 
+			#(-0.31 -0.31) 
+			#(-0.71 -1.01)
+		  ).
+	pca := PMPrincipalComponentAnalyserSVD new componentsNumber: 2.
+
+	pca fit: m.	
+	transformedData := pca transform: m.
+	
+	expected := PMMatrix rows: #(
+						#(-0.827970186 -0.175115307) 
+						#(1.77758033 0.142857227) 
+						#(-0.992197494 0.384374989) 
+						#(-0.274210416 0.130417207) 
+						#(-1.67580142 -0.209498461) 
+						#(-0.912949103 0.175282444) 
+						#(0.0991094375 -0.349824698) 
+						#(1.14457216 0.0464172582) 
+						#(0.438046137 0.0177646297) 
+						#(1.22382056 -0.162675287)).
+	self assert: (transformedData abs) closeTo: expected abs.
+]

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
@@ -22,37 +22,8 @@ PMPrincipalComponentAnalyserTest >> testPCAwithPCAandJacobiTransformationReturnS
 	self assert: pca1 transformMatrix abs closeTo: pca2 transformMatrix abs
 ]
 
-{ #category : #tests }
-PMPrincipalComponentAnalyserTest >> testTransformMatrixWithJacobiTransformation [
-	| m pca expected |
-	m := PMMatrix
-		rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
-	pca := PMPrincipalComponentAnalyserJacobiTransformation new
-		componentsNumber: 2.
-	
-	pca fit: m.
-	
-	expected := (PMMatrix
-		rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224))) abs.
-	self assert: pca transformMatrix abs closeTo: expected
-]
-
-{ #category : #tests }
-PMPrincipalComponentAnalyserTest >> testTransformMatrixWithSVD [
-	| m pca expected |
-	m := PMMatrix
-		rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
-	pca := PMPrincipalComponentAnalyserSVD new componentsNumber: 2.
-	
-	pca fit: m.
-	
-	expected := (PMMatrix
-		rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224))) abs.
-	self assert: pca transformMatrix abs closeTo: expected
-]
-
 { #category : #'pca tutorial' }
-PMPrincipalComponentAnalyserTest >> testTransformWithMeanCentredMeasurements [
+PMPrincipalComponentAnalyserTest >> testSVDBasedTransformWithMeanCentredMeasurements [
 	"As acceptance tests we use the worked example of the PCA tutorial of Lindsay Smith"
 
 	| m pca transformedData expected |
@@ -85,4 +56,33 @@ PMPrincipalComponentAnalyserTest >> testTransformWithMeanCentredMeasurements [
 						#(0.438046137 0.0177646297) 
 						#(1.22382056 -0.162675287)).
 	self assert: (transformedData abs) closeTo: expected abs.
+]
+
+{ #category : #tests }
+PMPrincipalComponentAnalyserTest >> testTransformMatrixWithJacobiTransformation [
+	| m pca expected |
+	m := PMMatrix
+		rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
+	pca := PMPrincipalComponentAnalyserJacobiTransformation new
+		componentsNumber: 2.
+	
+	pca fit: m.
+	
+	expected := (PMMatrix
+		rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224))) abs.
+	self assert: pca transformMatrix abs closeTo: expected
+]
+
+{ #category : #tests }
+PMPrincipalComponentAnalyserTest >> testTransformMatrixWithSVD [
+	| m pca expected |
+	m := PMMatrix
+		rows: #(#(-1 -1) #(-2 -1) #(-3 -2) #(1 1) #(2 1) #(3 2)).
+	pca := PMPrincipalComponentAnalyserSVD new componentsNumber: 2.
+	
+	pca fit: m.
+	
+	expected := (PMMatrix
+		rows: #(#(-0.83849224 -0.54491354) #(0.54491354 -0.83849224))) abs.
+	self assert: pca transformMatrix abs closeTo: expected
 ]

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMPrincipalComponentAnalyserTest.class.st
@@ -1,3 +1,9 @@
+"
+The tests in this class compare the output from PolyMath with: 
+1) an example from Scikit-Learn's documentation; and
+2) the PCA Tutorial by Lindsay Smith (see http://www.cs.otago.ac.nz/cosc453/student_tutorials/principal_components.pdf). The input data used
+are the mean-centred data in section 3.1, step 2.
+"
 Class {
 	#name : #PMPrincipalComponentAnalyserTest,
 	#superclass : #TestCase,
@@ -9,6 +15,41 @@ Class {
 	],
 	#category : #'Math-Tests-PrincipalComponentAnalysis'
 }
+
+{ #category : #'pca tutorial' }
+PMPrincipalComponentAnalyserTest >> testJacobiBasedTransformWithMeanCentredMeasurements [
+	"As acceptance tests we use the worked example of the PCA tutorial of Lindsay Smith"
+	| m pca transformedData expected |
+	m := PMMatrix rows: #(
+			#(0.69 0.49) 
+			#(-1.31 -1.21) 
+			#(0.39 0.99) 
+			#(0.09  0.29) 
+			#(1.29 1.09) 
+			#(0.49 0.79) 
+			#(0.19 -0.31) 
+			#(-0.81 -0.81) 
+			#(-0.31 -0.31) 
+			#(-0.71 -1.01)
+		  ).
+	pca := PMPrincipalComponentAnalyserJacobiTransformation new componentsNumber: 2.
+
+	pca fit: m.	
+	transformedData := pca transform: m.
+	
+	expected := PMMatrix rows: #(
+						#(-0.827970186 -0.175115307) 
+						#(1.77758033 0.142857227) 
+						#(-0.992197494 0.384374989) 
+						#(-0.274210416 0.130417207) 
+						#(-1.67580142 -0.209498461) 
+						#(-0.912949103 0.175282444) 
+						#(0.0991094375 -0.349824698) 
+						#(1.14457216 0.0464172582) 
+						#(0.438046137 0.0177646297) 
+						#(1.22382056 -0.162675287)).
+	self assert: (transformedData abs) closeTo: expected abs.
+]
 
 { #category : #tests }
 PMPrincipalComponentAnalyserTest >> testPCAwithPCAandJacobiTransformationReturnSame [


### PR DESCRIPTION
Issue #81 

In relation to the [first and second of our action points](https://github.com/PolyMathOrg/PolyMath/issues/81#issuecomment-477072192), I used the worked example from the [PCA Tutorial By Lindsay Smith](http://www.cs.otago.ac.nz/cosc453/student_tutorials/principal_components.pdf). As input, I used the **mean centred** data and what I was able to find is that our output from PolyMath match the output computed in the above-mentioned source. 

#### PCA Tutorial Paper's Output:

| x | y |
| ----| ---- |
| -.827970186 | -.175115307 |
| 1.77758033 | .142857227 |
| -.992197494 | .384374989 |
| -.274210416 | .130417207 |
| -1.67580142 | -.209498461 |
| -.912949103 | .175282444 |
| .0991094375 | -.349824698 |
| 1.14457216 | .0464172582 |
| .438046137 | .0177646297 |
| 1.22382056 | -.162675287 |

#### PolyMath:

##### SVD-Based Implementation of PCA:

![polymath_pca_tutorial_example](https://user-images.githubusercontent.com/2665571/56459656-64d99e00-638e-11e9-9734-7daa2b8c42ac.png)

##### Jacobi-Based Implementation of PCA

![PolyMathPCATutorialExample_Jacobi](https://user-images.githubusercontent.com/2665571/56459670-acf8c080-638e-11e9-8af1-f642ac86e639.png)

The chief conclusion we can draw is that our data are correct up to the negated signs.

#### Scikit-Learn
Scikit Learn matches the output of the paper exactly:
```
[[-0.82797019 -0.17511531]
 [ 1.77758033  0.14285723]
 [-0.99219749  0.38437499]
 [-0.27421042  0.13041721]
 [-1.67580142 -0.20949846]
 [-0.9129491   0.17528244]
 [ 0.09910944 -0.3498247 ]
 [ 1.14457216  0.04641726]
 [ 0.43804614  0.01776463]
 [ 1.22382056 -0.16267529]]
```
The gist for the python code that generated the above may be found [here](https://gist.github.com/hemalvarambhia/03e23c9d499d8b4d0b19849c90c53279).

This PR simply adds acceptance tests for the PCA objects' `transform:` message, using the worked example of the above-mentioned paper.