### PR TITLE
Removed == method from PMVector

### DIFF
--- a/src/Math-Core/PMVector.class.st
+++ b/src/Math-Core/PMVector.class.st
@@ -89,12 +89,6 @@ PMVector >> < aNumber [
 	1 to: self size do: [ :n | self at: n put: (self at: n) < aNumber].
 ]
 
-{ #category : #comparing }
-PMVector >> == aNumber [
-	"Apply == operator to every element of a vector"
-	1 to: self size do: [ :n | self at: n put: (self at: n) == aNumber].
-]
-
 { #category : #operation }
 PMVector >> > aNumber [
 	"Apply > function to every element of a vector"


### PR DESCRIPTION
The == operator should not be overridden. Removed that block entirely due to it having no real application.

Fixes issue #90.
