### PR TITLE
Added `rtValue:` in PMPolynomial for Roassal plots

### DIFF
--- a/src/Math-Polynomials/PMPolynomial.class.st
+++ b/src/Math-Polynomials/PMPolynomial.class.st
@@ -256,6 +256,13 @@ PMPolynomial >> roots: aNumber [
 	^roots
 ]
 
+{ #category : #Roassal2 }
+PMPolynomial >> rtValue: aNumber [
+	"This message makes PMPolynomial compatible with Roassal"
+
+	^ self value: aNumber
+]
+
 { #category : #'double dispatching' }
 PMPolynomial >> subtractToPolynomial: aPolynomial [
 


### PR DESCRIPTION
Fixes issue #109.

The following code does not work:
```Smalltalk
f := PMPolynomial coefficients: #(0 -1 -2 1).
grapher := RTGrapher new.
ds := RTData new.
ds noDot.
ds points: (-5 to: 5 by: 0.1).
ds y: f.
ds x: #yourself.
ds connectColor: (Color random).
grapher add: ds.
grapher
```
Roassal plots fails when you inspect `grapher`, since the render-er tries to compute min and max of x and y, and computes min/max of y as:
```
computed := elements collect: y.
 ```
where `elements` is a `RTGroup` consisting of `RTElements` with all x values provided by the user.

`RTGroup` in `collect:` method uses `RTData y: blockOrSymbol` method which basically does this:
```
self yElement: [ :anElement | blockOrSymbol rtValue: anElement model ]
```
So, the `blockOrSymbol` is our PMPolynomial object, which we supplied at `ds y: f`. `Object` class consists of `rtValue:` which returns `self`, causing `computed` object made up of `PMPolynomial` objects and not `Number`, failing it.