### PR TITLE
Issue 29 - PMVector/PMMatrix >> #dot: does not compute a dot product.

### DIFF
--- a/src/Math-Core/PMVector.class.st
+++ b/src/Math-Core/PMVector.class.st
@@ -20,7 +20,7 @@ Class {
 	#name : #PMVector,
 	#superclass : #Array,
 	#type : #variable,
-	#category : 'Math-Core'
+	#category : #'Math-Core'
 }
 
 { #category : #'instance creation' }
@@ -180,6 +180,21 @@ PMVector >> dot: aVector [
 		].
 	^answer
 
+]
+
+{ #category : #operation }
+PMVector >> elementwiseTimes: aVector [
+	"Answers the elementwise product of the receiver with aVector."
+
+	| answer n |
+	answer := self class new: self size.
+	n := 0.
+	self
+		with: aVector
+		do: [ :a :b | 
+			n := n + 1.
+			answer at: n put: a * b ].
+	^ answer
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Math-Core/PMVector.class.st
+++ b/src/Math-Core/PMVector.class.st
@@ -167,7 +167,7 @@ PMVector >> cumsum [
  
 ]
 
-{ #category : #operation }
+{ #category : #deprecated }
 PMVector >> dot: aVector [
 "Answers the elementwise product of the receiver with aVector."
 	| answer n |

--- a/src/Math-Core/PMVector.class.st
+++ b/src/Math-Core/PMVector.class.st
@@ -183,7 +183,7 @@ PMVector >> dot: aVector [
 ]
 
 { #category : #operation }
-PMVector >> elementwiseTimes: aVector [
+PMVector >> hadamardProduct: aVector [
 	"Answers the elementwise product of the receiver with aVector."
 
 	| answer n |

--- a/src/Math-Core/PMWeightedPoint.class.st
+++ b/src/Math-Core/PMWeightedPoint.class.st
@@ -12,7 +12,7 @@ Class {
 		'weight',
 		'error'
 	],
-	#category : 'Math-Core'
+	#category : #'Math-Core'
 }
 
 { #category : #creation }

--- a/src/Math-Matrix/PMJacobiTransformationHelper.class.st
+++ b/src/Math-Matrix/PMJacobiTransformationHelper.class.st
@@ -8,7 +8,7 @@ Class {
 		'eigenvalues',
 		'eigenvectors'
 	],
-	#category : 'Math-Matrix'
+	#category : #'Math-Matrix'
 }
 
 { #category : #creation }

--- a/src/Math-Matrix/PMLUPDecomposition.class.st
+++ b/src/Math-Matrix/PMLUPDecomposition.class.st
@@ -26,7 +26,7 @@ Class {
 		'permutation',
 		'parity'
 	],
-	#category : 'Math-Matrix'
+	#category : #'Math-Matrix'
 }
 
 { #category : #creation }

--- a/src/Math-Matrix/PMLargestEigenValueFinder.class.st
+++ b/src/Math-Matrix/PMLargestEigenValueFinder.class.st
@@ -20,7 +20,7 @@ Class {
 		'eigenvector',
 		'transposeEigenvector'
 	],
-	#category : 'Math-Matrix'
+	#category : #'Math-Matrix'
 }
 
 { #category : #information }

--- a/src/Math-Matrix/PMLinearEquationSystem.class.st
+++ b/src/Math-Matrix/PMLinearEquationSystem.class.st
@@ -22,7 +22,7 @@ Class {
 		'rows',
 		'solutions'
 	],
-	#category : 'Math-Matrix'
+	#category : #'Math-Matrix'
 }
 
 { #category : #creation }

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -15,7 +15,7 @@ Class {
 		'rows',
 		'lupDecomposition'
 	],
-	#category : 'Math-Matrix'
+	#category : #'Math-Matrix'
 }
 
 { #category : #example }
@@ -31,7 +31,7 @@ b := PMMatrix rows: #( ( 1 2 3 ) (-2 1 7)).
 c := a * b.
 
 "Elementwise matrix product"
-d := a dot:b.
+d := a hadamardProduct: b.
 
 "This is how we can create a vector"
 a := #(1 4 9 16 25) asPMVector.
@@ -407,7 +407,7 @@ PMMatrix >> dimension [
 	^ self rows size @ (self rows at: 1) size
 ]
 
-{ #category : #operation }
+{ #category : #deprecated }
 PMMatrix >> dot: aMatrix [
 	"Answers the elementwise product of the receiver with aMatrix."
 	^ aMatrix elementwiseProductWithMatrix: self
@@ -456,6 +456,11 @@ PMMatrix >> flattenRows [
 	answer := #().
 	self rowsDo: [ :each | answer := answer , each asArray ].
 	^ answer asPMVector
+]
+
+{ #category : #operation }
+PMMatrix >> hadamardProduct: aMatrix [
+	^ aMatrix  elementwiseProductWithMatrix: self
 ]
 
 { #category : #comparing }

--- a/src/Math-Matrix/PMSingularMatrixError.class.st
+++ b/src/Math-Matrix/PMSingularMatrixError.class.st
@@ -5,7 +5,7 @@ some calculations dont work with singular matrices and result eg with errors lik
 Class {
 	#name : #PMSingularMatrixError,
 	#superclass : #ArithmeticError,
-	#category : 'Math-Matrix'
+	#category : #'Math-Matrix'
 }
 
 { #category : #accessing }

--- a/src/Math-Matrix/PMSingularValueDecomposition.class.st
+++ b/src/Math-Matrix/PMSingularValueDecomposition.class.st
@@ -40,7 +40,7 @@ Class {
 		'signU',
 		'signV'
 	],
-	#category : 'Math-Matrix'
+	#category : #'Math-Matrix'
 }
 
 { #category : #'instance creation' }

--- a/src/Math-Matrix/PMSymmetricMatrix.class.st
+++ b/src/Math-Matrix/PMSymmetricMatrix.class.st
@@ -4,7 +4,7 @@ This class can be instantiated like DhbMatrix via #rows:, but the user has to ma
 Class {
 	#name : #PMSymmetricMatrix,
 	#superclass : #PMMatrix,
-	#category : 'Math-Matrix'
+	#category : #'Math-Matrix'
 }
 
 { #category : #'instance creation' }

--- a/src/Math-PrincipalComponentAnalysis/PMSciKitLearnSVDFlipAlgorithm.class.st
+++ b/src/Math-PrincipalComponentAnalysis/PMSciKitLearnSVDFlipAlgorithm.class.st
@@ -78,10 +78,10 @@ PMSciKitLearnSVDFlipAlgorithm >> signs [
 
 { #category : #accessing }
 PMSciKitLearnSVDFlipAlgorithm >> uFlipped [
-	^ u dot: (self signMatrixForU).
+	^ u hadamardProduct: (self signMatrixForU).
 ]
 
 { #category : #accessing }
 PMSciKitLearnSVDFlipAlgorithm >> vFlipped [
-	^ v dot: (self signMatrixForV) .
+	^ v hadamardProduct: (self signMatrixForV) .
 ]

--- a/src/Math-Tests-Core/PMVectorTest.class.st
+++ b/src/Math-Tests-Core/PMVectorTest.class.st
@@ -152,20 +152,6 @@ PMVectorTest >> testVectorDotProduct [
 ]
 
 { #category : #tests }
-PMVectorTest >> testVectorElementwiseTimes [
-	"Code Example 8.1"
-
-	| u v w |
-	u := #(1 2 3) asPMVector.
-	v := #(3 4 5) asPMVector.
-	w := u elementwiseTimes: v.
-	self assert: (w size) equals: 3.
-	self assert: (w at: 1) equals: 3.
-	self assert: (w at: 2) equals: 8.
-	self assert: (w at: 3) equals: 15
-]
-
-{ #category : #tests }
 PMVectorTest >> testVectorGreater [
 
 | u w |
@@ -176,6 +162,20 @@ PMVectorTest >> testVectorGreater [
 	self assert: (w at: 2) equals: false.
 	self assert: (w at: 3) equals: true
 
+]
+
+{ #category : #tests }
+PMVectorTest >> testVectorHadamardProduct [
+	"Code Example 8.1"
+
+	| u v w |
+	u := #(1 2 3) asPMVector.
+	v := #(3 4 5) asPMVector.
+	w := u hadamardProduct: v.
+	self assert: (w size) equals: 3.
+	self assert: (w at: 1) equals: 3.
+	self assert: (w at: 2) equals: 8.
+	self assert: (w at: 3) equals: 15
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Core/PMVectorTest.class.st
+++ b/src/Math-Tests-Core/PMVectorTest.class.st
@@ -152,6 +152,20 @@ PMVectorTest >> testVectorDotProduct [
 ]
 
 { #category : #tests }
+PMVectorTest >> testVectorElementwiseTimes [
+	"Code Example 8.1"
+
+	| u v w |
+	u := #(1 2 3) asPMVector.
+	v := #(3 4 5) asPMVector.
+	w := u elementwiseTimes: v.
+	self assert: (w size) equals: 3.
+	self assert: (w at: 1) equals: 3.
+	self assert: (w at: 2) equals: 8.
+	self assert: (w at: 3) equals: 15
+]
+
+{ #category : #tests }
 PMVectorTest >> testVectorGreater [
 
 | u w |

--- a/src/Math-Tests-Matrix/PMAdditionalTest.class.st
+++ b/src/Math-Tests-Matrix/PMAdditionalTest.class.st
@@ -5,7 +5,7 @@ here are tests that would be in Math-Tests-DHB-Numerical, if it could construct 
 Class {
 	#name : #PMAdditionalTest,
 	#superclass : #TestCase,
-	#category : 'Math-Tests-Matrix'
+	#category : #'Math-Tests-Matrix'
 }
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PMMatrixTest,
 	#superclass : #TestCase,
-	#category : 'Math-Tests-Matrix'
+	#category : #'Math-Tests-Matrix'
 }
 
 { #category : #tests }
@@ -428,7 +428,7 @@ PMMatrixTest >> testMatrixMultiplyElementwise [
 	| a b c |
 	a := PMMatrix rows: #(#(1 0 1) #(-1 -2 3)).
 	b := PMMatrix rows: #(#(1 2 3) #(-2 1 7)).
-	c := a dot:b.
+	c := a hadamardProduct: b.
 	self assert: c numberOfRows equals: 2.
 	self assert: c numberOfColumns equals: 3.
 	self assert: ((c rowAt: 1) at: 1) equals: 1.

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -352,6 +352,22 @@ PMMatrixTest >> testMatrixGreater [
 	self assert: ((b rowAt: 2) at: 3) equals: true
 ]
 
+{ #category : #'linear algebra' }
+PMMatrixTest >> testMatrixHadamardProduct [
+	| a b c |
+	a := PMMatrix rows: #(#(1 0 1) #(-1 -2 3)).
+	b := PMMatrix rows: #(#(1 2 3) #(-2 1 7)).
+	c := a hadamardProduct: b.
+	self assert: c numberOfRows equals: 2.
+	self assert: c numberOfColumns equals: 3.
+	self assert: ((c rowAt: 1) at: 1) equals: 1.
+	self assert: ((c rowAt: 1) at: 2) equals: 0.
+	self assert: ((c rowAt: 1) at: 3) equals: 3.
+	self assert: ((c rowAt: 2) at: 1) equals: 2.
+	self assert: ((c rowAt: 2) at: 2) equals: -2.
+	self assert: ((c rowAt: 2) at: 3) equals: 21
+]
+
 { #category : #comparing }
 PMMatrixTest >> testMatrixHash [
 	| a b c |
@@ -428,7 +444,7 @@ PMMatrixTest >> testMatrixMultiplyElementwise [
 	| a b c |
 	a := PMMatrix rows: #(#(1 0 1) #(-1 -2 3)).
 	b := PMMatrix rows: #(#(1 2 3) #(-2 1 7)).
-	c := a hadamardProduct: b.
+	c := a dot: b.
 	self assert: c numberOfRows equals: 2.
 	self assert: c numberOfColumns equals: 3.
 	self assert: ((c rowAt: 1) at: 1) equals: 1.

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PMQRTest,
 	#superclass : #TestCase,
-	#category : 'Math-Tests-Matrix'
+	#category : #'Math-Tests-Matrix'
 }
 
 { #category : #running }

--- a/src/Math-Tests-Matrix/PMRestTest.class.st
+++ b/src/Math-Tests-Matrix/PMRestTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PMRestTest,
 	#superclass : #TestCase,
-	#category : 'Math-Tests-Matrix'
+	#category : #'Math-Tests-Matrix'
 }
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMSingularValueDecompositionTest.class.st
+++ b/src/Math-Tests-Matrix/PMSingularValueDecompositionTest.class.st
@@ -35,7 +35,7 @@ Class {
 		'actualV',
 		'actualS'
 	],
-	#category : 'Math-Tests-Matrix'
+	#category : #'Math-Tests-Matrix'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Math-Tests-Matrix/PMSymmetricMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMSymmetricMatrixTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PMSymmetricMatrixTest,
 	#superclass : #TestCase,
-	#category : 'Math-Tests-Matrix'
+	#category : #'Math-Tests-Matrix'
 }
 
 { #category : #tests }


### PR DESCRIPTION
Issue: #29 
I looked at the wiki and found that [Hadamard product](https://en.wikipedia.org/wiki/Hadamard_product_(matrices)) is the name given to this binary operation. It is also known as the Schur product, however Serge and I agreed on `hadamardProduct:` as the name we might give the message.

Discussion around this issue raised a concern about silent breaks so I have introduced (added) the new `hadardProduct:` and marked `dot:` as deprecated. We can then defer when we want to remove the method completely.

I checked for usages and I have replaced calls to `dot:` everywhere except its use in the t-NSE package as @AtharvaKhare is currently doing some work there.