### PR TITLE
[Issue 29] PMVector/PMMatrix >> #dot: does not compute a dot product.

### DIFF
--- a/src/Math-Core/PMVector.class.st
+++ b/src/Math-Core/PMVector.class.st
@@ -20,7 +20,7 @@ Class {
 	#name : #PMVector,
 	#superclass : #Array,
 	#type : #variable,
-	#category : 'Math-Core'
+	#category : #'Math-Core'
 }
 
 { #category : #'instance creation' }
@@ -165,21 +165,6 @@ PMVector >> cumsum [
 	sum := 0.
 	^ self collect: [ :v | sum := sum + v. sum ]
  
-]
-
-{ #category : #deprecated }
-PMVector >> dot: aVector [
-"Answers the elementwise product of the receiver with aVector."
-	| answer n |
-	answer := self class new: self size.
-	n := 0.
-	self with: aVector do:
-		[ :a :b | 
-		  n := n + 1. 
-		  answer at: n put: ( a * b).
-		].
-	^answer
-
 ]
 
 { #category : #operation }

--- a/src/Math-Core/PMWeightedPoint.class.st
+++ b/src/Math-Core/PMWeightedPoint.class.st
@@ -12,7 +12,7 @@ Class {
 		'weight',
 		'error'
 	],
-	#category : 'Math-Core'
+	#category : #'Math-Core'
 }
 
 { #category : #creation }

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -407,12 +407,6 @@ PMMatrix >> dimension [
 	^ self rows size @ (self rows at: 1) size
 ]
 
-{ #category : #deprecated }
-PMMatrix >> dot: aMatrix [
-	"Answers the elementwise product of the receiver with aMatrix."
-	^ aMatrix elementwiseProductWithMatrix: self
-]
-
 { #category : #operation }
 PMMatrix >> eigen [
 	"Computes all eigenvalues and eigenvectors of a matrix.

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -430,7 +430,7 @@ PMMatrix >> elementwiseProductWithMatrix: aMatrix [
 	"Answers the elementwise product between aMatrix and the receiver as a Matrix."
 	| n |
 	n := 0.
-	^ PMMatrix rows: ( aMatrix rowsCollect: [ :each | n := n + 1. each dot: ( self rowAt: n)])
+	^ self class rows: ( aMatrix rowsCollect: [ :each | n := n + 1. each hadamardProduct: ( self rowAt: n)])
 
 ]
 

--- a/src/Math-Tests-Core/PMVectorTest.class.st
+++ b/src/Math-Tests-Core/PMVectorTest.class.st
@@ -138,20 +138,6 @@ PMVectorTest >> testVectorCumulativeSum [
 ]
 
 { #category : #tests }
-PMVectorTest >> testVectorDotProduct [
-	"Code Example 8.1"
-
-	| u v w |
-	u := #(1 2 3) asPMVector.
-	v := #(3 4 5) asPMVector.
-	w := u dot: v.
-	self assert: (w size) equals: 3.
-	self assert: (w at: 1) equals: 3.
-	self assert: (w at: 2) equals: 8.
-	self assert: (w at: 3) equals: 15
-]
-
-{ #category : #tests }
 PMVectorTest >> testVectorGreater [
 
 | u w |

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -438,24 +438,6 @@ PMMatrixTest >> testMatrixMultiply [
 ]
 
 { #category : #'linear algebra' }
-PMMatrixTest >> testMatrixMultiplyElementwise [
-	"Code Example 8.1"
-
-	| a b c |
-	a := PMMatrix rows: #(#(1 0 1) #(-1 -2 3)).
-	b := PMMatrix rows: #(#(1 2 3) #(-2 1 7)).
-	c := a dot: b.
-	self assert: c numberOfRows equals: 2.
-	self assert: c numberOfColumns equals: 3.
-	self assert: ((c rowAt: 1) at: 1) equals: 1.
-	self assert: ((c rowAt: 1) at: 2) equals: 0.
-	self assert: ((c rowAt: 1) at: 3) equals: 3.
-	self assert: ((c rowAt: 2) at: 1) equals: 2.
-	self assert: ((c rowAt: 2) at: 2) equals: -2.
-	self assert: ((c rowAt: 2) at: 3) equals: 21
-]
-
-{ #category : #'linear algebra' }
 PMMatrixTest >> testMatrixPrincipalDiagonal [
 	| a |
 	a := PMMatrix rows: #(#(1 2 3) #(4 5 6) #(7 8 9)).


### PR DESCRIPTION
Issue: #29
After introducing the correct name for the operation (Schur product/elementwise product are also options) I replaced all calls to the deprecated `dot:` with `hadamardProduct:` and finally removed the message completely.

We are happy to do this now as we have not released v1.0 yet.