### PR TITLE
Fixed ZeroDivideError in PMStandardizationScaler

### DIFF
--- a/src/Math-PrincipalComponentAnalysis/PMStandardizationScaler.class.st
+++ b/src/Math-PrincipalComponentAnalysis/PMStandardizationScaler.class.st
@@ -22,7 +22,11 @@ PMStandardizationScaler >> mean [
 
 { #category : #accessing }
 PMStandardizationScaler >> scale [
-	^ self variance sqrt
+	^ self variance collect: [ :element |
+		| root |
+		root := element sqrt.
+		(root ~= 0) ifTrue: [ root ] ifFalse: [ 1.0 ]
+		 ]
 ]
 
 { #category : #transforming }

--- a/src/Math-Tests-PrincipalComponentAnalysis/PMStandardizationScalerTest.class.st
+++ b/src/Math-Tests-PrincipalComponentAnalysis/PMStandardizationScalerTest.class.st
@@ -41,10 +41,30 @@ PMStandardizationScalerTest >> testTransformAnotherMatrix [
 ]
 
 { #category : #tests }
+PMStandardizationScalerTest >> testTransformConstantFeature [
+	| aMatrix t |
+	aMatrix := PMMatrix rows: #(#(8.0 0.0) #(8.0 0.0) #(8.0 1.0) #(8.0 1.0)).
+	t := PMStandardizationScaler new.
+	self assert: (t fitAndTransform: aMatrix) equals: (PMMatrix rows: #(#(0.0 -1.0) #(0.0 -1.0) #(0.0 1.0) #(0.0 1.0)))
+]
+
+{ #category : #tests }
 PMStandardizationScalerTest >> testVariance [
 	| aMatrix t |
 	aMatrix := PMMatrix rows: #((0.0 0.0) #(0.0 0.0) #(1.0 1.0) #(1.0 1.0)).
 	t := PMStandardizationScaler new.
 	t fit: aMatrix.
 	self assert: t variance asArray closeTo: #(0.25 0.25)
+]
+
+{ #category : #tests }
+PMStandardizationScalerTest >> testZeroScale [
+	"Tests if PMStandardizationScaler handles case when scale is 0, by changing it to 1.
+	 Happens when one feature is constant eg: 8.0 in this test."
+	
+	| aMatrix t |
+	aMatrix := PMMatrix rows: #((8.0 0.0) #(8.0 0.0) #(8.0 1.0) #(8.0 1.0)).
+	t := PMStandardizationScaler new.
+	t fit: aMatrix.
+	self assert: t scale asArray closeTo: #(1.0 0.5)
 ]


### PR DESCRIPTION
This happened when one of the input features was constant.
- Set scale to 1 for the feature which is constant
- Added two tests for this case

Fixes #124.