### PR TITLE
[Issue 105] Math-Random package is messy

### DIFF
--- a/src/Math-Random/PMLinearCongruentialRandomGenerator.class.st
+++ b/src/Math-Random/PMLinearCongruentialRandomGenerator.class.st
@@ -9,7 +9,7 @@ Class {
 	#category : #'Math-Random'
 }
 
-{ #category : #accessing }
+{ #category : #'stream access' }
 PMLinearCongruentialRandomGenerator >> next [
 	"Answer a pseudo-Random floating point number between 0 and 1. Uses a quick and dirty Linear congruential generator"
 
@@ -24,7 +24,7 @@ PMLinearCongruentialRandomGenerator >> nextFloat [
 	^ seed / 120050.0
 ]
 
-{ #category : #accessing }
+{ #category : #'stream access' }
 PMLinearCongruentialRandomGenerator >> peek [
 	"Answer a pseudo-Random floating point number between 0 and 1.  Uses a simple, but fast, Linear Congruential generator."
 

--- a/src/Math-Random/PMMersenneTwisterRandomGenerator.class.st
+++ b/src/Math-Random/PMMersenneTwisterRandomGenerator.class.st
@@ -134,11 +134,11 @@ PMMersenneTwisterRandomGenerator >> nextInteger [
 				put: ((states at: PeriodParameter) bitXor: ((y bitShift: 1) bitXor: (tempArray at: (y bitAnd: 16r1) + 1))).
 			mti := 0 ].
 	y := states at: mti + 1.
-	mti := mti + 1.
 	y := y bitXor: (y bitShift: 11 negated).
 	y := y bitXor: ((y bitShift: 7 negated) bitAnd: TemperingMaskB).
 	y := y bitXor: ((y bitShift: 15 negated) bitAnd: TemperingMaskC).
 	y := y bitXor: (y bitShift: 18 negated).
+	mti := mti + 1.
 	^ y
 ]
 

--- a/src/Math-Random/PMMersenneTwisterRandomGenerator.class.st
+++ b/src/Math-Random/PMMersenneTwisterRandomGenerator.class.st
@@ -108,36 +108,38 @@ PMMersenneTwisterRandomGenerator >> nextInteger [
 	"Answer a random integer on [0,0xffffffff] interval"
 
 	| tempArray y |
-	tempArray := Array withAll: #(0 16r9908B0DF).
+	tempArray := Array withAll: #(0 2567483615).
 	mti >= DefaultLengthVector
-		ifTrue: [ 
-			mti = (DefaultLengthVector + 1)
-				ifTrue: [ 
-					self seed: 5489.
+		ifTrue: [ mti = (DefaultLengthVector + 1)
+				ifTrue: [ self seed: 5489.
 					self initialize ].
 			1 to: DefaultLengthVector - PeriodParameter do: [ :kk | 
-				y := ((states at: kk) bitAnd: Mt19937UpperMask) bitOr: ((states at: kk + 1) bitAnd: Mt19937LowerMask).
+				y := ((states at: kk) bitAnd: Mt19937UpperMask)
+					bitOr: ((states at: kk + 1) bitAnd: Mt19937LowerMask).
 				states
 					at: kk
 					put:
-						(((states at: kk + PeriodParameter) bitXor: (y bitShift: 1 negated)) bitXor: (tempArray at: (y bitAnd: 16r1) + 1)) ].
-			DefaultLengthVector - PeriodParameter + 1 to: DefaultLengthVector - 2 do: [ :kk | 
-				y := ((states at: kk) bitAnd: Mt19937UpperMask) bitOr: ((states at: kk + 1) bitAnd: Mt19937LowerMask).
+						(((states at: kk + PeriodParameter) bitXor: (y bitShift: 1 negated))
+							bitXor: (tempArray at: (y bitAnd: 1) + 1)) ].
+			DefaultLengthVector - PeriodParameter + 1 to: DefaultLengthVector - 2
+			do: [ :kk | 
+				y := ((states at: kk) bitAnd: Mt19937UpperMask)
+					bitOr: ((states at: kk + 1) bitAnd: Mt19937LowerMask).
 				states
 					at: kk
 					put:
-						(((states at: kk + PeriodParameter - DefaultLengthVector + 1) bitXor: (y bitShift: 1 negated))
-							bitXor: (tempArray at: (y bitAnd: 16r1) + 1)) ].
-			y := ((states at: DefaultLengthVector) bitAnd: Mt19937UpperMask) bitOr: ((states at: 1) bitAnd: Mt19937LowerMask).
+						(((states at: kk + PeriodParameter - DefaultLengthVector + 1)
+							bitXor: (y bitShift: 1 negated))
+							bitXor: (tempArray at: (y bitAnd: 1) + 1)) ].
+			y := ((states at: DefaultLengthVector) bitAnd: Mt19937UpperMask)
+				bitOr: ((states at: 1) bitAnd: Mt19937LowerMask).
 			states
 				at: DefaultLengthVector
-				put: ((states at: PeriodParameter) bitXor: ((y bitShift: 1) bitXor: (tempArray at: (y bitAnd: 16r1) + 1))).
+				put:
+					((states at: PeriodParameter)
+						bitXor: ((y bitShift: 1) bitXor: (tempArray at: (y bitAnd: 1) + 1))).
 			mti := 0 ].
-	y := states at: mti + 1.
-	y := y bitXor: (y bitShift: 11 negated).
-	y := y bitXor: ((y bitShift: 7 negated) bitAnd: TemperingMaskB).
-	y := y bitXor: ((y bitShift: 15 negated) bitAnd: TemperingMaskC).
-	y := y bitXor: (y bitShift: 18 negated).
+	y := self temperAt: mti + 1.
 	mti := mti + 1.
 	^ y
 ]
@@ -148,4 +150,15 @@ PMMersenneTwisterRandomGenerator >> peek [
 	
 	^ self copy next
 	
+]
+
+{ #category : #private }
+PMMersenneTwisterRandomGenerator >> temperAt: position [
+	| y |
+	y := states at: position.
+	y := y bitXor: (y bitShift: 11 negated).
+	y := y bitXor: ((y bitShift: 7 negated) bitAnd: TemperingMaskB).
+	y := y bitXor: ((y bitShift: 15 negated) bitAnd: TemperingMaskC).
+	y := y bitXor: (y bitShift: 18 negated).
+	^ y
 ]

--- a/src/Math-Random/PMMersenneTwisterRandomGenerator.class.st
+++ b/src/Math-Random/PMMersenneTwisterRandomGenerator.class.st
@@ -108,7 +108,7 @@ PMMersenneTwisterRandomGenerator >> nextInteger [
 	"Answer a random integer on [0,0xffffffff] interval"
 
 	| tempArray y |
-	tempArray := Array withAll: #(0 2567483615).
+	tempArray := Array withAll: #(0 16r9908B0DF).
 	mti >= DefaultLengthVector
 		ifTrue: [ mti = (DefaultLengthVector + 1)
 				ifTrue: [ self seed: 5489.

--- a/src/Math-Random/PMParkMillerMinimumRandomGenerator.class.st
+++ b/src/Math-Random/PMParkMillerMinimumRandomGenerator.class.st
@@ -9,7 +9,7 @@ Class {
 	#category : #'Math-Random'
 }
 
-{ #category : #accessing }
+{ #category : #'stream access' }
 PMParkMillerMinimumRandomGenerator >> next [
     "Answer a pseudo-Random floating point number between 0 and 1.
     Uses Park and Miller's 'Minimum Standard' congruential generator
@@ -30,7 +30,7 @@ PMParkMillerMinimumRandomGenerator >> nextFloat [
     ^ seed / 16r7FFFFFFF asFloat 
 ]
 
-{ #category : #accessing }
+{ #category : #'stream access' }
 PMParkMillerMinimumRandomGenerator >> peek [
     "Answer a pseudo-Random floating point number between 0 and 1.
     Uses Park and Miller's 'Minimum Standard' congruential generator."


### PR DESCRIPTION
Issue: #105 
This PR looks at:
- reducing the long method smell in the `PMMersenneTwisterRandomGenerator` class' `nextInteger` method. Here I extracted the block of code that performs 'tempering' to an intention-revealing method, using [the original paper](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/ARTICLES/mt.pdf) for guidance on naming. No new tests were written as this is the tiniest refactor I could perform given the lack of knowledge I have in this area. I used defect injection to check the existing tests gave me sufficient covering;
- correcting the Parker-Miller and Congruential class' method categorisations so that they match the super class's.
A future PR will look at adding more tests to increase confidence in refactoring.

