### PR TITLE
[Issue 106] Support For coveralls.io

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -18,6 +18,7 @@ SmalltalkCISpec {
 	'Math-K*',
 	'Math-M*',
 	'Math-N*',
+	'Math-O*',
 	'Math-Random' ]
     }
   }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -13,6 +13,7 @@ SmalltalkCISpec {
 	'Math-ArbitraryPrecisionFloat',
 	'Math-AutomaticDifferenciation',
 	'Math-B*',
+	'Math-C*',
 	'Math-Random' ]
     }
   }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -19,6 +19,7 @@ SmalltalkCISpec {
 	'Math-M*',
 	'Math-N*',
 	'Math-P*',
+	'Math-Q*',
 	'Math-Random' ]
     }
   }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -16,6 +16,7 @@ SmalltalkCISpec {
 	'Math-C*',
 	'Math-D*',
 	'Math-K*',
+	'Math-M*',
 	'Math-Random' ]
     }
   }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -20,7 +20,7 @@ SmalltalkCISpec {
 	'Math-N*',
 	'Math-P*',
 	'Math-Q*',
-	'Math-Random' ]
+	'Math-R*' ]
     }
   }
 }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -8,7 +8,7 @@ SmalltalkCISpec {
   ],
   #testing : {
     #coverage : {
-      #packages : [ 'Math-Random' ]
+      #packages : [ 'Math-Accuracy-ODE', 'Math-Random' ]
     }
   }
 }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -15,6 +15,7 @@ SmalltalkCISpec {
 	'Math-B*',
 	'Math-C*',
 	'Math-D*',
+	'Math-F*',
 	'Math-Random' ]
     }
   }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -7,6 +7,6 @@ SmalltalkCISpec {
     }
   ],
  #testing : {
-      #packages : [ 'Math-*' ]
+      #packages : [ 'Math-Random' ]
     }
 }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -8,7 +8,11 @@ SmalltalkCISpec {
   ],
   #testing : {
     #coverage : {
-      #packages : [ 'Math-Accuracy-ODE', 'Math-Random' ]
+      #packages : [
+        'Math-Accuracy-ODE',
+	'Math-ArbitraryPrecisionFloat',
+	'Math-AutomaticDifferenciation',
+	'Math-Random' ]
     }
   }
 }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -20,7 +20,8 @@ SmalltalkCISpec {
 	'Math-N*',
 	'Math-P*',
 	'Math-Q*',
-	'Math-R*' ]
+	'Math-R*',
+	'Math-TNSE' ]
     }
   }
 }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -6,7 +6,9 @@ SmalltalkCISpec {
       #platforms : [ #pharo ]
     }
   ],
- #testing : {
+  #testing : {
+    #coverage : {
       #packages : [ 'Math-Random' ]
     }
+  }
 }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -14,6 +14,7 @@ SmalltalkCISpec {
 	'Math-AutomaticDifferenciation',
 	'Math-B*',
 	'Math-C*',
+	'Math-D*',
 	'Math-Random' ]
     }
   }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -15,7 +15,7 @@ SmalltalkCISpec {
 	'Math-B*',
 	'Math-C*',
 	'Math-D*',
-	'Math-F*',
+	'Math-K*',
 	'Math-Random' ]
     }
   }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -12,6 +12,7 @@ SmalltalkCISpec {
         'Math-Accuracy-ODE',
 	'Math-ArbitraryPrecisionFloat',
 	'Math-AutomaticDifferenciation',
+	'Math-B*',
 	'Math-Random' ]
     }
   }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -17,6 +17,7 @@ SmalltalkCISpec {
 	'Math-D*',
 	'Math-K*',
 	'Math-M*',
+	'Math-N*',
 	'Math-Random' ]
     }
   }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -18,7 +18,7 @@ SmalltalkCISpec {
 	'Math-K*',
 	'Math-M*',
 	'Math-N*',
-	'Math-O*',
+	'Math-P*',
 	'Math-Random' ]
     }
   }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
 [![Build Status](https://travis-ci.org/PolyMathOrg/PolyMath.svg?branch=master)](https://travis-ci.org/PolyMathOrg/PolyMath)
 [![Build status](https://ci.appveyor.com/api/projects/status/3tvarh2xi22max8h?svg=true)](https://ci.appveyor.com/project/SergeStinckwich/polymath-88bea)
-[![Coverage Status](https://coveralls.io/repos/github/PolyMathOrg/PolyMath/badge.svg)](https://coveralls.io/github/PolyMathOrg/PolyMath)
+[![Coverage Status](https://coveralls.io/repos/github/PolyMathOrg/PolyMath/badge.svg?branch=issue-106)](https://coveralls.io/github/PolyMathOrg/PolyMath?branch=issue-106)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/PolyMathOrg/PolyMath/master/LICENSE)
 
 <img width="1675" alt="Screenshot 2019-04-24 at 11 12 57" src="https://user-images.githubusercontent.com/327334/56652094-66eb7780-6682-11e9-9753-101be18df67c.png">


### PR DESCRIPTION
Issue: #106

I have added test coverage tool coveralls.io and discovered along the way that some packages cause the SmallTalkCI to fail, including: 
- Math-FFT and Math-FunctionFit;
- Math-ODE
- Math-Accuracy

I would like to address these in the next PR. This one gets a slice out the door so that we can observe the current landscape and the confidence we may have in refactoring code.