### PR TITLE
[Issue 106] Refactor Math-Accuracy

### DIFF
--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -209,14 +209,17 @@ PMAccuracy >> extremeCollection: acol max:aBoolean [
 
 { #category : #private }
 PMAccuracy >> findKey [
-	| s selector |
+	| s selector matchingMessage |
 	s := thisContext sender.
-	selector := s sender method selector .
-	^(names detect: [:name| selector endsWith: name] ifNone: [nil]) 
-		ifNil: [ selector='initialize' 
-			ifTrue: ['AllTheRest'] 
-			ifFalse: [ selector := s method selector. 
-					self error: selector,' called in wrong context'] ]
+	selector := s sender method selector.
+	matchingMessage := names
+		detect: [ :name | selector endsWith: name ]
+		ifNone: [ nil ].
+	^ matchingMessage
+		ifNil: [ selector = 'initialize'
+				ifTrue: [ 'AllTheRest' ]
+				ifFalse: [ selector := s method selector.
+					self error: selector , ' called in wrong context' ] ]
 ]
 
 { #category : #printing }

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -270,14 +270,15 @@ PMAccuracy >> initSubclassSelectorNames [
 
 { #category : #'initialize-release' }
 PMAccuracy >> initialize [
-	self initSubclassSelectorNames.
 	parameters := Dictionary new.
 	arguments := Dictionary new.
 	results := Dictionary new.
+	self initSubclassSelectorNames.
+	names do: [ :name | self initRest: name ].
 	aStream := WriteStream with: ''.
 	iterations := 1.
-	dataTree := KeyedTree new .
-	names do: [ :name | self initRest: name ]
+	dataTree := KeyedTree new.
+	
 ]
 
 { #category : #accessing }

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -212,7 +212,8 @@ PMAccuracy >> findKey [
 	| s selector matchingMessage |
 	s := thisContext sender.
 	selector := s sender method selector.
-	selector = 'initialize' ifTrue: [ ^ 'AllTheRest' ].
+	selector = 'initialize'
+		ifTrue: [ ^ 'AllTheRest' ].
 	matchingMessage := names
 		detect: [ :name | selector endsWith: name ]
 		ifNone: [ nil ].

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -216,9 +216,8 @@ PMAccuracy >> findKey [
 		ifTrue: [ ^ 'AllTheRest' ].
 	matchingMessage := names
 		detect: [ :name | selector endsWith: name ]
-		ifNone: [ nil ].
+		ifNone: [ self error: (s method selector join: ' called in wrong context') ].
 	^ matchingMessage
-		ifNil: [ self error: s method selector , ' called in wrong context' ]
 ]
 
 { #category : #printing }

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -307,9 +307,7 @@ PMAccuracy >> numberOfDifferentResultsAt: aname [
 
 { #category : #accessing }
 PMAccuracy >> occurrencesOf: key In: aResults UpTo: anInteger [
-	| repetitions |
-	repetitions := (aResults copyFrom: 1 to: anInteger) occurrencesOf: key.
-	^ repetitions
+	^ (aResults copyFrom: 1 to: anInteger) occurrencesOf: key
 ]
 
 { #category : #accessing }

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -216,7 +216,7 @@ PMAccuracy >> findKey [
 		ifTrue: [ ^ 'AllTheRest' ].
 	matchingMessage := names
 		detect: [ :name | selector endsWith: name ]
-		ifNone: [ self error: (s method selector , ' called in wrong context') ].
+		ifNone: [ '' ].
 	^ matchingMessage
 ]
 

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -308,13 +308,7 @@ PMAccuracy >> numberOfDifferentResultsAt: aname [
 { #category : #accessing }
 PMAccuracy >> occurrencesOf: key In: aResults UpTo: anInteger [
 	| repetitions |
-	repetitions := 0.
-	aResults
-		from: 1
-		to: anInteger
-		do: [ :i | 
-			i = key
-				ifTrue: [ repetitions := repetitions + 1 ] ].
+	repetitions := (aResults copyFrom: 1 to: anInteger) occurrencesOf: key.
 	^ repetitions
 ]
 

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -215,7 +215,7 @@ PMAccuracy >> findKey [
 	^(names detect: [:name| selector endsWith: name] ifNone: [nil]) 
 		ifNil: [ selector='initialize' 
 			ifTrue: ['AllTheRest'] 
-			ifFalse: [ selector := s method selector asString. 
+			ifFalse: [ selector := s method selector. 
 					self error: selector,' called in wrong context'] ]
 ]
 

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -212,12 +212,12 @@ PMAccuracy >> findKey [
 	| s selector matchingMessage |
 	s := thisContext sender.
 	selector := s sender method selector.
+	selector = 'initialize' ifTrue: [ ^ 'AllTheRest' ].
 	matchingMessage := names
 		detect: [ :name | selector endsWith: name ]
 		ifNone: [ nil ].
 	^ matchingMessage
 		ifNil: [ selector = 'initialize'
-				ifTrue: [ 'AllTheRest' ]
 				ifFalse: [ self error: s method selector , ' called in wrong context' ] ]
 ]
 

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -218,8 +218,7 @@ PMAccuracy >> findKey [
 	^ matchingMessage
 		ifNil: [ selector = 'initialize'
 				ifTrue: [ 'AllTheRest' ]
-				ifFalse: [ selector := s method selector.
-					self error: selector , ' called in wrong context' ] ]
+				ifFalse: [ self error: s method selector , ' called in wrong context' ] ]
 ]
 
 { #category : #printing }

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -306,6 +306,19 @@ PMAccuracy >> numberOfDifferentResultsAt: aname [
 ]
 
 { #category : #accessing }
+PMAccuracy >> occurrencesOf: key In: aResults UpTo: anInteger [
+	| repetitions |
+	repetitions := 0.
+	aResults
+		from: 1
+		to: anInteger
+		do: [ :i | 
+			i = key
+				ifTrue: [ repetitions := repetitions + 1 ] ].
+	^ repetitions
+]
+
+{ #category : #accessing }
 PMAccuracy >> parameter [
 	| r |
 	r := self parameterAt: self findKey.
@@ -396,15 +409,9 @@ PMAccuracy >> resultsKeyFor: aName AtPosition: anInteger [
 	key := aResults at: anInteger.
 	key isArray
 		ifFalse: [ ^ aResults ].
-	repetitions := 0.
-	aResults
-		from: 1
-		to: anInteger - 1
-		do: [ :i | 
-			i = key
-				ifTrue: [ repetitions := repetitions + 1 ] ].
+	repetitions := self occurrencesOf: key In: aResults UpTo: anInteger - 1.
 	result := (Array new: key size + repetitions)
-		replaceFrom: 1 
+		replaceFrom: 1
 		to: key size
 		with: key
 		startingAt: 1.

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -256,7 +256,8 @@ PMAccuracy >> initRest: aName [
 	| initializationMessage |
 	initializationMessage := ('initialize' , aName) asSymbol.
 	(self respondsTo: initializationMessage)
-		ifTrue: [ self perform: initializationMessage ] 
+		ifFalse: [ ^ self ].
+	self perform: initializationMessage
 ]
 
 { #category : #'initialize-release' }

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -216,7 +216,7 @@ PMAccuracy >> findKey [
 		ifTrue: [ ^ 'AllTheRest' ].
 	matchingMessage := names
 		detect: [ :name | selector endsWith: name ]
-		ifNone: [ self error: (s method selector join: ' called in wrong context') ].
+		ifNone: [ self error: (s method selector , ' called in wrong context') ].
 	^ matchingMessage
 ]
 

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -218,8 +218,7 @@ PMAccuracy >> findKey [
 		detect: [ :name | selector endsWith: name ]
 		ifNone: [ nil ].
 	^ matchingMessage
-		ifNil: [ selector = 'initialize'
-				ifFalse: [ self error: s method selector , ' called in wrong context' ] ]
+		ifNil: [ self error: s method selector , ' called in wrong context' ]
 ]
 
 { #category : #printing }

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -252,7 +252,15 @@ PMAccuracy >> ifSeveralterations: aBlock [
 ]
 
 { #category : #'initialize-release' }
-PMAccuracy >> initNames [
+PMAccuracy >> initRest: aName [
+	| initializationMessage |
+	initializationMessage := ('initialize' , aName) asSymbol.
+	(self respondsTo: initializationMessage)
+		ifTrue: [ self perform: initializationMessage ] 
+]
+
+{ #category : #'initialize-release' }
+PMAccuracy >> initSubclassSelectorNames [
 	names := (self class allSelectorsBelow: Object)
 		select: [ :s | s beginsWith: #check ]
 		thenCollect: [ :s | s copyFrom: 6 to: s size ].
@@ -260,16 +268,8 @@ PMAccuracy >> initNames [
 ]
 
 { #category : #'initialize-release' }
-PMAccuracy >> initRest: aName [
-	| i |
-	i := ('initialize' , aName) asSymbol.
-	(self respondsTo: i)
-		ifTrue: [ self perform: i ] 
-]
-
-{ #category : #'initialize-release' }
 PMAccuracy >> initialize [
-	self initNames.
+	self initSubclassSelectorNames.
 	parameters := Dictionary new.
 	arguments := Dictionary new.
 	results := Dictionary new.

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -277,7 +277,7 @@ PMAccuracy >> initialize [
 	aStream := WriteStream with: ''.
 	iterations := 1.
 	dataTree := KeyedTree new .
-	names do: [ :n | self initRest: n ]
+	names do: [ :name | self initRest: name ]
 ]
 
 { #category : #accessing }

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -212,7 +212,7 @@ PMAccuracy >> findKey [
 	| s m |
 	s := thisContext sender.
 	m := s sender method selector .
-	^(names detect: [:n| m asString endsWith: n] ifNone: [nil]) 
+	^(names detect: [:n| m endsWith: n] ifNone: [nil]) 
 		ifNil: [ m='initialize' 
 			ifTrue: ['AllTheRest'] 
 			ifFalse: [ m := s method selector asString. 

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -212,7 +212,7 @@ PMAccuracy >> findKey [
 	| s selector |
 	s := thisContext sender.
 	selector := s sender method selector .
-	^(names detect: [:n| selector endsWith: n] ifNone: [nil]) 
+	^(names detect: [:name| selector endsWith: name] ifNone: [nil]) 
 		ifNil: [ selector='initialize' 
 			ifTrue: ['AllTheRest'] 
 			ifFalse: [ selector := s method selector asString. 
@@ -263,8 +263,8 @@ PMAccuracy >> initRest: aName [
 { #category : #'initialize-release' }
 PMAccuracy >> initSubclassSelectorNames [
 	names := (self class allSelectorsBelow: Object)
-		select: [ :s | s beginsWith: #check ]
-		thenCollect: [ :s | s copyFrom: 6 to: s size ].
+		select: [ :selectorName | selectorName beginsWith: #check ]
+		thenCollect: [ :selectorName | selectorName copyFrom: 6 to: selectorName size ].
 	names := names asArray sort
 ]
 

--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -209,14 +209,14 @@ PMAccuracy >> extremeCollection: acol max:aBoolean [
 
 { #category : #private }
 PMAccuracy >> findKey [
-	| s m |
+	| s selector |
 	s := thisContext sender.
-	m := s sender method selector .
-	^(names detect: [:n| m endsWith: n] ifNone: [nil]) 
-		ifNil: [ m='initialize' 
+	selector := s sender method selector .
+	^(names detect: [:n| selector endsWith: n] ifNone: [nil]) 
+		ifNil: [ selector='initialize' 
 			ifTrue: ['AllTheRest'] 
-			ifFalse: [ m := s method selector asString. 
-					self error: m,' called in wrong context'] ]
+			ifFalse: [ selector := s method selector asString. 
+					self error: selector,' called in wrong context'] ]
 ]
 
 { #category : #printing }

--- a/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
@@ -39,11 +39,6 @@ PMAccuracyTest >> testArgumentAt [
 ]
 
 { #category : #tests }
-PMAccuracyTest >> testArgumentError [
-	self should: [ a testArgumentError ] raise: Error
-]
-
-{ #category : #tests }
 PMAccuracyTest >> testAsArray [
 	self assert: (a asArray: 'bla') equals: #('bla').
 	self assert: (a asArray: #('bla')) equals: #('bla').
@@ -272,11 +267,6 @@ PMAccuracyTest >> testParameterAt [
 ]
 
 { #category : #tests }
-PMAccuracyTest >> testParameterError [
-self should: [a testParameterError ]raise: Error
-]
-
-{ #category : #tests }
 PMAccuracyTest >> testPrintOn [
 	| s |
 	s := WriteStream on: String new.
@@ -298,11 +288,6 @@ PMAccuracyTest >> testReport [
 	self assert: a report equals: ''.
 	a run.
 	self assert: (a report beginsWith: 'Report for: PMAccuracyTestExample')
-]
-
-{ #category : #tests }
-PMAccuracyTest >> testResultError [
-self should: [a testResultError ]raise: Error
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
@@ -111,11 +111,6 @@ count :=count-(1/5).
 ]
 
 { #category : #private }
-PMAccuracyTestExample >> testArgumentError [
-self argument: #(#(1) #(2)).
-]
-
-{ #category : #private }
 PMAccuracyTestExample >> testGetterAaa [
 ^{ self parameter .self argument.self resultsAt: 'Aaa'.self numberOfDifferentParametersAt: 'Aaa'.self numberOfDifferentResultsAt:'Aaa'}
 ]
@@ -123,14 +118,4 @@ PMAccuracyTestExample >> testGetterAaa [
 { #category : #private }
 PMAccuracyTestExample >> testGetterBbb [
 ^{ self parameter .self argument.self resultsAt: 'Bbb'.self numberOfDifferentParametersAt: 'Bbb'.self numberOfDifferentResultsAt:'Bbb'}
-]
-
-{ #category : #private }
-PMAccuracyTestExample >> testParameterError [
-self parameter:  #(#(1) #(2)).
-]
-
-{ #category : #private }
-PMAccuracyTestExample >> testResultError [
-self result:#(1).
 ]


### PR DESCRIPTION
Issue: #106 

The `Math-Accuracy` package causes breakages in the coverage part of smalltalkCI. Debugging the root cause is hard because the package itself is a little hard to follow. This refactor, the first of many, aims to make the package much easier to understand.

The automated tests seem to very effective at catching bugs as one particular refactor I performed caused tests to fail.

Having refactored `findKey` we discovered that if a key is not found, an error is raised. I appealed to @WernerK via the mailing list and he suggested remove the error raising code entirely if it was causing problems. In this PR, then, I decided to return an empty string to keep the interface post-condition consistent, in that it will always return a string.