### PR TITLE
[Issue 106] Get Math-ODE Covered By Coveralls.io 

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -19,7 +19,7 @@ SmalltalkCISpec {
 	'Math-K*',
 	'Math-M*',
 	'Math-N*',
-	'Math-O*',
+	'Math-ODE',
 	'Math-P*',
 	'Math-Q*',
 	'Math-R*',

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -19,6 +19,7 @@ SmalltalkCISpec {
 	'Math-K*',
 	'Math-M*',
 	'Math-N*',
+	'Math-O*',
 	'Math-P*',
 	'Math-Q*',
 	'Math-R*',


### PR DESCRIPTION
Issue #106 

Here I have got the `Math-ODE` package covered by coverall.io. I tried to list 'Math-O*' originally but some travis jobs failed, running out of memory, so as a small step forward I have hard-coded the package name until we can find a better way forward.