### PR TITLE
Updated SMark version to 1.0.3

### DIFF
--- a/src/BaselineOfPolyMath/BaselineOfPolyMath.class.st
+++ b/src/BaselineOfPolyMath/BaselineOfPolyMath.class.st
@@ -180,7 +180,7 @@ BaselineOfPolyMath >> sMark: spec [
 		project: 'SMark'
 		with: [ spec
 				className: #ConfigurationOfSMark;
-				versionString: '1.0.2';
+				versionString: '1.0.3';
 				repository: 'http://smalltalkhub.com/mc/StefanMarr/SMark/main' ]
 ]
 


### PR DESCRIPTION
This commit should fix the compilation errors in PharoGs that were reported for SMark.