### PR TITLE
[Issue 152] Remove Magic From 'initialize' Methods

### DIFF
--- a/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
@@ -64,40 +64,44 @@ self parameter: #(#(1) #(3))
 
 { #category : #'initialize-release' }
 PMAccuracyTestExample >> initializeAaa [
-"this overrides defaults in #initialize:"
-self result: #(#(5 3) #(4 4)).
-self argument: #(#(false) #(true)).
-self parameter: #(#(1 2) #(3 2.8888))
+	"this overrides defaults in #initialize:"
+
+	self result: #(#(5 3) #(4 4)).
+	self argument: #(#(false) #(true)).
+	self parameter: #(#(1 2) #(3 2.8888))
 ]
 
 { #category : #'initialize-release' }
 PMAccuracyTestExample >> initializeCcc [
-"this overrides defaults in initialize"
-self result: #((1)(1)(1)).
-self argument: #((1)(1.1)(0.9)).
+	"this overrides defaults in initialize"
+
+	self result: #(#(1) #(1) #(1)).
+	self argument: #(#(1) #(1.1) #(0.9))
 ]
 
 { #category : #'initialize-release' }
 PMAccuracyTestExample >> initializeDdd [
-"this overrides defaults in initialize"
-self result: #(1.1 2.2).
-self argument: #()."necessary since otherwise the default values defined in #initialize would be used"
-self parameter: #().
+	"this overrides defaults in initialize"
+
+	self result: #(1.1 2.2).
+	self argument: #().	"necessary since otherwise the default values defined in #initialize would be used"
+	self parameter: #()
 ]
 
 { #category : #'initialize-release' }
 PMAccuracyTestExample >> initializeEee [
-"this overrides defaults in initialize"
-self result: #(#(1.1 2.2) #(1 3)).
+	"this overrides defaults in initialize"
 
+	self result: #(#(1.1 2.2) #(1 3))
 ]
 
 { #category : #'initialize-release' }
 PMAccuracyTestExample >> initializeFff [
-"this overrides defaults in initialize"
-self result: #(0 1 0 -2 3).
-self argument: nil.
-self parameter:nil.
+	"this overrides defaults in initialize"
+
+	self result: #(0 1 0 -2 3).
+	self argument: nil.
+	self parameter: nil
 ]
 
 { #category : #running }

--- a/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
@@ -67,7 +67,7 @@ PMAccuracyTestExample >> initializeAaa [
 	"this overrides defaults in #initialize:"
 
 	self result: #(#(5 3) #(4 4)).
-	self argument: #(#(false) #(true)).
+	self map: 'Aaa' to: #(#(false) #(true)).
 	self parameter: #(#(1 2) #(3 2.8888))
 ]
 
@@ -76,7 +76,7 @@ PMAccuracyTestExample >> initializeCcc [
 	"this overrides defaults in initialize"
 
 	self result: #(#(1) #(1) #(1)).
-	self argument: #(#(1) #(1.1) #(0.9))
+	self map: 'Ccc' to: #(#(1) #(1.1) #(0.9))
 ]
 
 { #category : #'initialize-release' }
@@ -84,7 +84,7 @@ PMAccuracyTestExample >> initializeDdd [
 	"this overrides defaults in initialize"
 
 	self result: #(1.1 2.2).
-	self argument: #().	"necessary since otherwise the default values defined in #initialize would be used"
+	self map: 'Ddd' to: #(). 
 	self parameter: #()
 ]
 
@@ -100,8 +100,16 @@ PMAccuracyTestExample >> initializeFff [
 	"this overrides defaults in initialize"
 
 	self result: #(0 1 0 -2 3).
-	self argument: nil.
+	self map: 'Fff' to: nil.
 	self parameter: nil
+]
+
+{ #category : #'initialize-release' }
+PMAccuracyTestExample >> map: key to: anArgument [
+	arguments
+		at: key
+		put: (anArgument ifNotNil: [ :a | self asArray: a ]).
+	^ anArgument
 ]
 
 { #category : #running }

--- a/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
@@ -15,51 +15,58 @@ Class {
 
 { #category : #tests }
 PMAccuracyTestExample >> checkAaa [
-self argument first ifTrue:[^#(1 1)].
-^{4 +(0.4 * Random new next) . 2}
+	self argument first
+		ifTrue: [ ^ #(1 1) ].
+	^ {(4 + (0.4 * Random new next)).
+	2}
 ]
 
 { #category : #tests }
 PMAccuracyTestExample >> checkBbb [
-^self argument first size +self parameter first 
+	^ self argument first size + self parameter first
 ]
 
 { #category : #tests }
 PMAccuracyTestExample >> checkCcc [
-^self argument first +(0.01*self parameter first).
+	^ self argument first + (0.01 * self parameter first)
 ]
 
 { #category : #tests }
 PMAccuracyTestExample >> checkDdd [
-^{2 .3 }asOrderedCollection 
+	^ {2 . 3} asOrderedCollection
 ]
 
 { #category : #tests }
 PMAccuracyTestExample >> checkEee [
-^{self parameter first .3 }
+	^ {self parameter first.
+	3}
 ]
 
 { #category : #tests }
 PMAccuracyTestExample >> checkFff [
-^{0. 0. 1. 0. Float nan}
+	^ {0.
+	0.
+	1.
+	0.
+	Float nan}
 ]
 
 { #category : #private }
 PMAccuracyTestExample >> count [
-^count
+	^ count
 ]
 
 { #category : #'initialize-release' }
-PMAccuracyTestExample >> initialize [ 
-"this is always necessarily the first thing:"
-super initialize .
-"this is only for testSetup:"
-count:=0.
-"now you can set defaults:"
-self result: #(#(2)#(3)).
-self argument: #(#('a') #('AG')).
-self parameter: #(#(1) #(3))
+PMAccuracyTestExample >> initialize [
+	"this is always necessarily the first thing:"
 
+	super initialize.
+	"this is only for testSetup:"
+	count := 0.
+	"now you can set defaults:"
+	self result: #(#(2) #(3)).
+	self argument: #(#('a') #('AG')).
+	self parameter: #(#(1) #(3))
 ]
 
 { #category : #'initialize-release' }
@@ -113,21 +120,29 @@ PMAccuracyTestExample >> map: key to: anArgument [
 ]
 
 { #category : #running }
-PMAccuracyTestExample >> setUp [ 
-count :=count+1.
+PMAccuracyTestExample >> setUp [
+	count := count + 1
 ]
 
 { #category : #running }
 PMAccuracyTestExample >> tearDown [
-count :=count-(1/5).
+	count := count - (1 / 5)
 ]
 
 { #category : #private }
 PMAccuracyTestExample >> testGetterAaa [
-^{ self parameter .self argument.self resultsAt: 'Aaa'.self numberOfDifferentParametersAt: 'Aaa'.self numberOfDifferentResultsAt:'Aaa'}
+	^ {self parameter.
+	self argument.
+	(self resultsAt: 'Aaa').
+	(self numberOfDifferentParametersAt: 'Aaa').
+	(self numberOfDifferentResultsAt: 'Aaa')}
 ]
 
 { #category : #private }
 PMAccuracyTestExample >> testGetterBbb [
-^{ self parameter .self argument.self resultsAt: 'Bbb'.self numberOfDifferentParametersAt: 'Bbb'.self numberOfDifferentResultsAt:'Bbb'}
+	^ {self parameter.
+	self argument.
+	(self resultsAt: 'Bbb').
+	(self numberOfDifferentParametersAt: 'Bbb').
+	(self numberOfDifferentResultsAt: 'Bbb')}
 ]


### PR DESCRIPTION
Issue: #152 

This PR removed some magic from initialising key-value pairs as it was causing [travis to fail](https://travis-ci.org/PolyMathOrg/PolyMath/builds/572469507) when the package test coverage was analysed by coveralls.io.

To confirm that my refactors were safe to do, I injected defects into the work to make sure that tests were failing.