### PR TITLE
[issue-154] Corrected the behaviour of findKey to return 'AllTheRest' when selector has no corresponding initialize message.

### DIFF
--- a/src/Math-Tests-Accuracy/PMAccuracyFindKeyTest.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyFindKeyTest.class.st
@@ -4,21 +4,29 @@ This test case exercises the findKey: message with some regression tests.
 Class {
 	#name : #PMAccuracyFindKeyTest,
 	#superclass : #TestCase,
+	#instVars : [
+		'accuracy'
+	],
 	#category : #'Math-Tests-Accuracy'
 }
 
-{ #category : #tests }
-PMAccuracyFindKeyTest >> testFindKeyReturnsAllTheRestStringWhenSelectorCorrespondsToNonExistentProperty [
-	| accuracy |
+{ #category : #running }
+PMAccuracyFindKeyTest >> setUp [ 
+	super setUp.
 	accuracy := PMAccuracyTestExample new.
 	
-	self assert: (accuracy findKey: 'NonExistent') equals: 'AllTheRest'
+]
+
+{ #category : #tests }
+PMAccuracyFindKeyTest >> testFindKeyReturnsAllTheRestStringWhenSelectorCorrespondsToNonExistentProperty [
+	| selector |
+	selector := 'NonExistent'.
+	self assert: (accuracy findKey: selector) equals: 'AllTheRest'
 ]
 
 { #category : #tests }
 PMAccuracyFindKeyTest >> testFindKeyReturnsAllTheRestStringWhenSelectorIsInitialize [
-	| accuracy selector |
-	accuracy := PMAccuracyTestExample new.
+	| selector |
 	selector := 'initialize'.
 	
 	self assert: (accuracy findKey: selector) equals: 'AllTheRest'
@@ -26,8 +34,7 @@ PMAccuracyFindKeyTest >> testFindKeyReturnsAllTheRestStringWhenSelectorIsInitial
 
 { #category : #tests }
 PMAccuracyFindKeyTest >> testFindKeyReturnsPropertyWhenSelectorIsSuffixOfInitializePropertyMessage [
-	| accuracy |
-	accuracy := PMAccuracyTestExample new.
-	
-	self assert: (accuracy findKey: 'Aaa') equals: 'Aaa'
+	| selector |
+	selector := 'Aaa'.
+	self assert: (accuracy findKey: selector) equals: selector
 ]

--- a/src/Math-Tests-Accuracy/PMAccuracyFindKeyTest.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyFindKeyTest.class.st
@@ -10,6 +10,11 @@ Class {
 	#category : #'Math-Tests-Accuracy'
 }
 
+{ #category : #tests }
+PMAccuracyFindKeyTest >> assertKeyFor: selector equals: expected [
+	self assert: (accuracy findKey: selector) equals: expected
+]
+
 { #category : #running }
 PMAccuracyFindKeyTest >> setUp [ 
 	super setUp.
@@ -21,7 +26,8 @@ PMAccuracyFindKeyTest >> setUp [
 PMAccuracyFindKeyTest >> testFindKeyReturnsAllTheRestStringWhenSelectorCorrespondsToNonExistentProperty [
 	| selector |
 	selector := 'NonExistent'.
-	self assert: (accuracy findKey: selector) equals: 'AllTheRest'
+	
+	self assertKeyFor: selector equals: 'AllTheRest'
 ]
 
 { #category : #tests }
@@ -29,12 +35,13 @@ PMAccuracyFindKeyTest >> testFindKeyReturnsAllTheRestStringWhenSelectorIsInitial
 	| selector |
 	selector := 'initialize'.
 	
-	self assert: (accuracy findKey: selector) equals: 'AllTheRest'
+	self assertKeyFor: selector equals: 'AllTheRest'
 ]
 
 { #category : #tests }
 PMAccuracyFindKeyTest >> testFindKeyReturnsPropertyWhenSelectorIsSuffixOfInitializePropertyMessage [
 	| selector |
 	selector := 'Aaa'.
-	self assert: (accuracy findKey: selector) equals: selector
+	
+	self assertKeyFor: selector equals: 'Aaa'
 ]

--- a/src/Math-Tests-Accuracy/PMAccuracyFindKeyTest.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyFindKeyTest.class.st
@@ -1,0 +1,33 @@
+"
+This test case exercises the findKey: message with some regression tests.
+"
+Class {
+	#name : #PMAccuracyFindKeyTest,
+	#superclass : #TestCase,
+	#category : #'Math-Tests-Accuracy'
+}
+
+{ #category : #tests }
+PMAccuracyFindKeyTest >> testFindKeyReturnsAllTheRestStringWhenSelectorCorrespondsToNonExistentProperty [
+	| accuracy |
+	accuracy := PMAccuracyTestExample new.
+	
+	self assert: (accuracy findKey: 'NonExistent') equals: 'AllTheRest'
+]
+
+{ #category : #tests }
+PMAccuracyFindKeyTest >> testFindKeyReturnsAllTheRestStringWhenSelectorIsInitialize [
+	| accuracy selector |
+	accuracy := PMAccuracyTestExample new.
+	selector := 'initialize'.
+	
+	self assert: (accuracy findKey: selector) equals: 'AllTheRest'
+]
+
+{ #category : #tests }
+PMAccuracyFindKeyTest >> testFindKeyReturnsPropertyWhenSelectorIsSuffixOfInitializePropertyMessage [
+	| accuracy |
+	accuracy := PMAccuracyTestExample new.
+	
+	self assert: (accuracy findKey: 'Aaa') equals: 'Aaa'
+]

--- a/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
@@ -56,6 +56,25 @@ PMAccuracyTestExample >> count [
 	^ count
 ]
 
+{ #category : #private }
+PMAccuracyTestExample >> findKey [
+	| s selector |
+	s := thisContext sender.
+	selector := s sender method selector.
+	^ self findKey: selector
+]
+
+{ #category : #private }
+PMAccuracyTestExample >> findKey: selector [
+	| matchingMessage |
+	selector = 'initialize'
+		ifTrue: [ ^ 'AllTheRest' ].
+	matchingMessage := names
+		detect: [ :name | selector endsWith: name ]
+		ifNone: [ 'AllTheRest' ].
+	^ matchingMessage
+]
+
 { #category : #'initialize-release' }
 PMAccuracyTestExample >> initialize [
 	"this is always necessarily the first thing:"


### PR DESCRIPTION
I discovered while working on #154 that the `testArgumentAt:` test was [still failing](https://travis-ci.org/PolyMathOrg/PolyMath/builds/582400649). I carried out a quick spike to see if setting `matchingMessage` to `'AllTheRest'` when the property is not `'initialize'` or a property with a corresponding `'initialize<Property>'` message fixes it, [and it does](https://travis-ci.org/PolyMathOrg/PolyMath/jobs/582403224).

To mitigate risk at this stage, I corrected `findKey` by correcting the behaviour in the subclass defined in the test package (`PMAccuracyTestExample`). I began by extracting some of the code to a more testable method, `findKey:` and using that in the said overriding message. Regression tests were written for the newly extracted method to ensure no new bugs were introduced:

### Test list:
- when selector is 'initialize' return 'AllTheRest';
- when selector is a property with a initializeProperty message, return the property;
- when selector does not have a corresponding initialize message, return 'AllTheRest'