### PR TITLE
Remove curly braces

### DIFF
--- a/src/Math-Accuracy-Core/PMAccuracy.class.st
+++ b/src/Math-Accuracy-Core/PMAccuracy.class.st
@@ -134,7 +134,7 @@ PMAccuracy >> argumentAt: aName [
 PMAccuracy >> asArray: aCol [ 
 	^(aCol isCollection and: [ aCol isSequenceable and: [aCol isString not] ])  
 		ifTrue: [ aCol asArray ] 
-		ifFalse: [ {aCol} ]
+		ifFalse: [ Array with: aCol ]
 ]
 
 { #category : #private }
@@ -302,7 +302,7 @@ no isCollection ifFalse: [^1].
 PMAccuracy >> numberOfDifferentResultsAt: aname [
 	|no|
 	no := self resultsAt: aname.
-	no isCollection ifFalse:[no:={no}].
+	no isCollection ifFalse:[no:= Array with: no].
 	^ no first isCollection ifTrue: [ no size ] ifFalse: [ 1 ]
 ]
 

--- a/src/Math-Benchmarks-ODE/PMODEBenchmark.class.st
+++ b/src/Math-Benchmarks-ODE/PMODEBenchmark.class.st
@@ -38,7 +38,7 @@ PMODEBenchmark class >> runAllToXML: numOfIterations [
 		xml.
 	writer tag: 'smark' with: [ 
 		(self runAll: numOfIterations) do: [ :runner |
-			writer tag: 'suite' attributes: { #name -> runner suite class name asString } asDictionary with: [  
+			writer tag: 'suite' attributes: (Dictionary with: #name -> runner suite class name asString) with: [  
 				runner results keysAndValuesDo: [ :key :value |
 					writer tag: key with: ((value inject: 0 into: [ :subTotal :result |
 								subTotal + result total ]) / value size) asFloat asString] ] ] ].

--- a/src/Math-Core-Process/PMFixpoint.class.st
+++ b/src/Math-Core-Process/PMFixpoint.class.st
@@ -64,7 +64,7 @@ verbose ifFalse: [ ^self ].
 GrowlMorph 
 			openWithLabel: 'Info'
 			contents: ('{1} iterations used.
-warning: {2}-cycle detected' format: {iterations. cycleLength})
+warning: {2}-cycle detected' format: (Array with: iterations with: cycleLength))
 			color: Color gray muchDarker
 ]
 
@@ -151,7 +151,7 @@ PMFixpoint >> simpleInfo [
 verbose ifFalse: [ ^self ].
 GrowlMorph 
 			openWithLabel: 'Info' 
-			contents: ('{1} iterations needed.' format: {iterations}) 
+			contents: ('{1} iterations needed.' format: (Array with: iterations)) 
 			color: Color green muchDarker
 ]
 
@@ -161,7 +161,7 @@ verbose ifFalse: [ ^self ].
 GrowlMorph 
 			openWithLabel: 'Warning' 
 			contents: ('maximumIterations ({1}) reached.
-you can run evaluate a second time' format: {maximumIterations}) 
+you can run evaluate a second time' format: (Array with: maximumIterations)) 
 			color: Color orange darker
 ]
 

--- a/src/Math-Core/PMVector.class.st
+++ b/src/Math-Core/PMVector.class.st
@@ -203,7 +203,7 @@ PMVector >> householder [
 				put: ((x <=0) ifTrue: [x -u] ifFalse:  [0 - s / (x + u)]).
 			b :=(v at: 1) squared * 2 / (s + (v at: 1) squared).
 			v := v / (v at: 1) ].
-	^{b. v}
+	^Array with: b with: v
 ]
 
 { #category : #operation }

--- a/src/Math-FastFourierTransform/PMFastFourierTransform.class.st
+++ b/src/Math-FastFourierTransform/PMFastFourierTransform.class.st
@@ -78,9 +78,7 @@ PMFastFourierTransform >> initPermTable [
 		r := (i - 1 bitReverse: nu) + 1.
 		r > i
 			ifTrue: [ permTable
-					add:
-						{i.
-						r} ] ]
+					add: (Array with: i with: r) ] ]
 ]
 
 { #category : #initializing }

--- a/src/Math-FunctionFit/PMGeneralFunctionFit.class.st
+++ b/src/Math-FunctionFit/PMGeneralFunctionFit.class.st
@@ -132,8 +132,10 @@ n:=0.
 [	self quartile: max.
 	self evaluate.
 	errorCol:= self errorCollection sort.
-	d2:=(errorFunction parameterSize to: (errorCol size -4) ) collect: [:i| {i+2.
-		(2*(errorCol at: i)) - (errorCol at: i+1) - (2*(errorCol at: i+2))- (errorCol at: i+3)+(2*(errorCol at: i+4))} ].
+	d2:=(errorFunction parameterSize to: (errorCol size -4) ) collect: [:i|
+		Array
+			with: (i+2)
+			with: ((2*(errorCol at: i)) - (errorCol at: i+1) - (2*(errorCol at: i+2))- (errorCol at: i+3)+(2*(errorCol at: i+4))) ].
 	[max :=#(5 0).
 	d2 do: [:d|((d at: 2) >= (max at:2)) ifTrue: [max :=d]].
 	(max first = (d2 last first))ifTrue: [
@@ -296,7 +298,7 @@ PMGeneralFunctionFit >> truncateData [
 |ec ei |
 dataTruncated ifTrue: [^Error signal:'data is already truncated'].
 ec:=self errorCollection .
-ei:=(ec withIndexCollect: [:e :i|{e.i}]).
+ei:=(ec withIndexCollect: [:e :i| Array with: e with: i]).
 ei:=(ei sort:[:a :b|a first<b first]) collect: [:e|e second ].
 ei :=ei copyFrom: 1 to: (self quartile * ec size) truncated.
 self resetResult.

--- a/src/Math-KDTree/PMIndexedKDTree.class.st
+++ b/src/Math-KDTree/PMIndexedKDTree.class.st
@@ -13,14 +13,12 @@ Class {
 { #category : #'instance creation' }
 PMIndexedKDTree class >> withAll: aCollectionOfCollections [
 "make a KDTree from a SequenceableCollection of SequenceableCollections ,which is an ordered Collection of points in a n-dimensional space. the nearest neighbour search then returns the indices of the neighbours"
-|c|
-c :=aCollectionOfCollections withIndexCollect: [:v :i| {i.v.}]  .
-^super withAll: c.  
+^super withAll: (aCollectionOfCollections withIndexCollect: [:v :i| Array with: i with: v ]).  
 ]
 
 { #category : #private }
 PMIndexedKDTree >> add: aDistance to: aNNStore [
-aNNStore add: {aDistance . {index . value}} .
+aNNStore add: (Array with: aDistance with: (Array with: index with: value)) .
 ]
 
 { #category : #private }
@@ -36,7 +34,7 @@ PMIndexedKDTree >> nnSearch: aSequenceableCollection i: anInt [
 |n|
 n :=PMNNStore new: anInt .
 self nnSearch: aSequenceableCollection asFloatArray near: n .
-^anInt =1 ifTrue: [n data first first ] ifFalse:   [n completeData collect: [:i | {(i at:2)first . i first}]  ]  
+^anInt =1 ifTrue: [n data first first ] ifFalse: [n completeData collect: [:i | Array with: (i at:2) first with: i first]  ]  
 ]
 
 { #category : #private }

--- a/src/Math-KDTree/PMKDTree.class.st
+++ b/src/Math-KDTree/PMKDTree.class.st
@@ -24,7 +24,7 @@ aCollectionOfCollections first ifEmpty: [self error: 'KDTree withAll: error'  ].
 
 { #category : #private }
 PMKDTree >> add: aDistance to: aNNStore [
-aNNStore add: {aDistance . value} .
+aNNStore add: (Array with: aDistance with: value) .
 ]
 
 { #category : #initialize }

--- a/src/Math-KDTree/PMNNStore.class.st
+++ b/src/Math-KDTree/PMNNStore.class.st
@@ -16,7 +16,7 @@ Class {
 
 { #category : #'instance creation' }
 PMNNStore class >> new: anInt [
-^((super new: anInt) atAllPut: {Float infinity. nil}  )initialize  
+^((super new: anInt) atAllPut: (Array with: Float infinity with: nil))initialize  
 ]
 
 { #category : #'instance creation' }
@@ -30,7 +30,7 @@ PMNNStore class >> newFrom: aCollectionWithSortingIndex [
 PMNNStore class >> withAll: aCollection [
 "this is the peferable form of instance creation for subclasses since freeIndex is correctly initialized this way. then 'sortFor:' must be overwritten and called at least once (!); an example is StupidNN. the other possibility is to use 'new:' and to fill NNStore subclass with 'add:' . the advantage is, that NNStore has not to be filled completely this way and the sorting logic can be applied outside of the subclass without sortFor: (see also comment on add:). 
 you cant enter the sorting index with the method withAll: . if you want to do that, use 'newFrom:' instead"
-^(super withAll: (aCollection collect: [:coll| {nil. coll}]))lastUsedIndex: aCollection size  
+^(super withAll: (aCollection collect: [:coll| Array with: nil with: coll]))lastUsedIndex: aCollection size  
 ]
 
 { #category : #comparing }

--- a/src/Math-KolmogorovSmirnov/PMKolmogorovSmirnov2Sample.class.st
+++ b/src/Math-KolmogorovSmirnov/PMKolmogorovSmirnov2Sample.class.st
@@ -63,17 +63,11 @@ PMKolmogorovSmirnov2Sample >> initCachedUCalculation [
 	cij := self cFrom: i and: j.
 	i * j = 0
 		ifTrue: [ cij ]
-		ifFalse: [ cij
-				*
-					((uCalcBlock
-						value:
-							{i.
-							(j - 1)})
-						+
-							(uCalcBlock
-								value:
-									{(i - 1).
-									j})) ] ] memoized
+		ifFalse: [ cij * (
+			(uCalcBlock value: (Array with: i with: j - 1))
+			+
+			(uCalcBlock value: (Array with: i - 1 with: j))
+		) ] ] memoized
 ]
 
 { #category : #initialization }
@@ -123,7 +117,7 @@ PMKolmogorovSmirnov2Sample >> ksStatistic [
 { #category : #private }
 PMKolmogorovSmirnov2Sample >> makeCDFOf: aCollection intoFirst: aBoolean [
 	"if aCollection consists of numbers, 
-it returns a sorted array of (number->{cdf.aBoolean})"
+it returns a sorted array of (number-> (Array with: cdf with: aBoolean))"
 
 	| cd s result |
 	cd := 0.
@@ -131,10 +125,7 @@ it returns a sorted array of (number->{cdf.aBoolean})"
 	result := aCollection asBag sortedElements
 		do: [ :a | 
 			cd := a value / s + cd.
-			a
-				value:
-					{cd.
-					aBoolean} ].
+			a value: (Array with: cd with: aBoolean) ].
 	^ aBoolean
 		ifTrue: [ data := result ]
 		ifFalse: [ compareWith := result ]
@@ -154,10 +145,8 @@ Kim, P. J. & Jennrich, R. I.
 in 'Selected Tables in Mathematical Statistics Volume I' (1973)."
 
 	ksStatistic ifNil: [ self ksStatistic ].
-	^ (uCalcBlock
-		value:
-			{smallSize.
-			bigSize}) / (smallSize + bigSize take: smallSize)
+	^ (uCalcBlock value: (Array with: smallSize with: bigSize))
+		/ (smallSize + bigSize take: smallSize)
 ]
 
 { #category : #printing }

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -670,7 +670,7 @@ PMMatrix >> qrFactorization [
 	i>0 ifTrue: [ r :=PMMatrix rows: (r rows copyFrom: 1 to:  colSize). 
 					i := q numberOfColumns - i. 
 					q := PMMatrix rows:  ( q rows collect: [:row| row copyFrom: 1 to: i]) ].  
-	^{q. r}
+	^Array with: q with: r
 ]
 
 { #category : #'as yet unclassified' }
@@ -729,9 +729,7 @@ PMMatrix >> qrFactorizationWithPivoting [
 			i := q numberOfColumns - i.
 			pivot := pivot copyFrom: 1 to: i.
 			q := PMMatrix rows: (q rows collect: [ :row | row copyFrom: 1 to: i ]) ].
-	^ {q.
-	r.
-	pivot}
+	^ Array with: q with: r with: pivot
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Math-ODE/PMAB2Solver.class.st
+++ b/src/Math-ODE/PMAB2Solver.class.st
@@ -64,7 +64,7 @@ PMAB2Solver >> mainStepsPrevState: prevState startTime: initialTime endTime: end
 			self announceState: state time: time + self dt.
 			lastTime := time + self dt].
 			
-	^ {previousState . state}
+	^ Array with: previousState with: state
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Math-ODE/PMAB3Solver.class.st
+++ b/src/Math-ODE/PMAB3Solver.class.st
@@ -56,7 +56,7 @@ PMAB3Solver >> mainStepsPrevState: prevState prevPrevState: prevPrevState startT
 			self announceState: state time: time + self dt.
 			lastTime := time + (3*self dt)].
 			
-	^ { previousPrevState. previousState}
+	^ Array with: previousPrevState with: previousState
 	
 ]
 

--- a/src/Math-ODE/PMAB4Solver.class.st
+++ b/src/Math-ODE/PMAB4Solver.class.st
@@ -63,7 +63,7 @@ PMAB4Solver >> mainStepsPrevState: prevState prevPrevState: prevPrevState initSt
 			self announceState: state time: time + self dt.
 			lastTime := time + (4*self dt)].
 			
-	^ { initialState. previousPrevState. previousState}
+	^ Array with: initialState with: previousPrevState with: previousState
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Math-ODE/PMAM3Solver.class.st
+++ b/src/Math-ODE/PMAM3Solver.class.st
@@ -64,7 +64,7 @@ PMAM3Solver >> mainStepsPrevState: prevState startTime: initialTime endTime: end
 			self announceState: state time: time + self dt.
 			lastTime := time + self dt].
 			
-	^ {previousState . state}
+	^ Array with: previousState with: state
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Math-ODE/PMAM4Solver.class.st
+++ b/src/Math-ODE/PMAM4Solver.class.st
@@ -55,7 +55,7 @@ PMAM4Solver >> mainStepsPrevState: prevState prevPrevState: prevPrevState startT
 			"announce step results"
 			self announceState: state time: time + self dt.
 			lastTime := time + self dt].  
-		^ { previousPrevState. previousState }
+		^ Array with: previousPrevState with: previousState
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Math-ODE/PMBDF2Solver.class.st
+++ b/src/Math-ODE/PMBDF2Solver.class.st
@@ -65,7 +65,7 @@ PMBDF2Solver >> mainStepsPrevState: prevState startTime: initialTime endTime: en
 			self announceState: state time: time + self dt.
 			lastTime := time + self dt].
 			
-	^ {previousState . state}
+	^ Array with: previousState with: state
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Math-ODE/PMBDF3Solver.class.st
+++ b/src/Math-ODE/PMBDF3Solver.class.st
@@ -54,7 +54,7 @@ PMBDF3Solver >> mainStepsPrevState: prevState prevPrevState: prevPrevState start
 			"announce step results"
 			self announceState: state time: time + self dt.
 			lastTime := time + self dt].  
-		^ { previousPrevState. previousState }
+		^ Array with: previousPrevState with: previousState
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Math-ODE/PMBDF4Solver.class.st
+++ b/src/Math-ODE/PMBDF4Solver.class.st
@@ -62,7 +62,7 @@ PMBDF4Solver >> mainStepsPrevState: prevState prevPrevState: prevPrevState initS
 			self announceState: state time: time + self dt.
 			lastTime := time + self dt].
 			
-	^ { initialState. previousPrevState. previousState}
+	^ Array with: initialState with: previousPrevState with: previousState
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Math-Permutation/PMPermutation.class.st
+++ b/src/Math-Permutation/PMPermutation.class.st
@@ -128,9 +128,9 @@ block:=[:nandk||n k|
 	(n=k and:[n isZero])
 		ifTrue:[1]
 		ifFalse:[	(n * k) isZero 
-				ifTrue:[0]
-				ifFalse:[ (block value:{n-1.k-1})+((n-1)*(block value:{n-1.k}))]]]memoized .
-^block value:{anInteger . anotherInteger }
+			ifTrue:[0]
+			ifFalse:[ (block value: (Array with: n-1 with: k-1))+((n-1)*(block value:(Array with: n-1 with: k)))]]]memoized .
+^block value: (Array with: anInteger with: anotherInteger)
 ]
 
 { #category : #converting }

--- a/src/Math-Quantile/SortedCollection.extension.st
+++ b/src/Math-Quantile/SortedCollection.extension.st
@@ -2,12 +2,12 @@ Extension { #name : #SortedCollection }
 
 { #category : #'*Math-Quantile' }
 SortedCollection >> california [
-	^ {0 . 0 . 0 . 1}
+	^ Array with: 0 with: 0 with: 0 with: 1
 ]
 
 { #category : #'*Math-Quantile' }
 SortedCollection >> closestObservation [
-	^ {1/2 . 0 . 0 . 0}
+	^ Array with: 1/2 with: 0 with: 0 with: 0
 ]
 
 { #category : #'*Math-Quantile' }
@@ -26,7 +26,7 @@ SortedCollection class >> example2 [
 
 { #category : #'*Math-Quantile' }
 SortedCollection >> hydrologist [
-	^ {1/2 . 0 . 0 . 1}
+	^ Array with: 1/2 with: 0 with: 0 with: 1
 ]
 
 { #category : #'*Math-Quantile' }
@@ -38,22 +38,22 @@ SortedCollection >> interQuartileRange [
 
 { #category : #'*Math-Quantile' }
 SortedCollection >> inverseCDF [
-	^ {0 . 0 . 1 . 0}
+	^ Array with: 0 with: 0 with: 1 with: 0
 ]
 
 { #category : #'*Math-Quantile' }
 SortedCollection >> medianBased [
-	^ {1/3 . 1/3 . 0 . 1}
+	^ Array with: 1/3 with: 1/3 with: 0 with: 1
 ]
 
 { #category : #'*Math-Quantile' }
 SortedCollection >> modeBased [
-	^ {1 . -1 . 0 . 1}
+	^ Array with: 1 with: -1 with: 0 with: 1
 ]
 
 { #category : #'*Math-Quantile' }
 SortedCollection >> normalDistribution [
-	^ {3/8 . 1/4 . 0 . 1}
+	^ Array with: 3/8 with: 1/4 with: 0 with: 1
 ]
 
 { #category : #'*Math-Quantile' }
@@ -95,5 +95,5 @@ SortedCollection >> quantile: aProbability withProbs: anArray [
 
 { #category : #'*Math-Quantile' }
 SortedCollection >> weibull [
-	^ {0 . 1 . 0 . 1}
+	^ Array with: 0 with: 1 with: 0 with: 1
 ]

--- a/src/Math-TSNE/PMTSNE.class.st
+++ b/src/Math-TSNE/PMTSNE.class.st
@@ -80,8 +80,8 @@ PMTSNE class >> exampleGridWithVizualization [
 	"We assign a color to the elements"
 	rec := Rectangle encompassing: (tsne y rows 
 		collect: [:row | row first @ row second ]).
-	xscale := TSScale linear domain: { rec origin x. rec corner x }.
-	yscale := TSScale linear domain: { rec origin y. rec corner y }.
+	xscale := TSScale linear domain: (Array with rec origin x with: rec corner x).
+	yscale := TSScale linear domain: (Array with rec origin y with: rec corner y).
 	s := RSShapeBuilder circle
 		size: 5;
 		color: [:vec | Color
@@ -153,7 +153,7 @@ PMTSNE class >> gridDataGeneratorOf: size [
 	| array i |
 	array := Array new: size*size. 
 	i := 1.
-	1 to: size do: [ :x | 1 to: size do: [ :y | array at: i  put: {x. y.}.
+	1 to: size do: [ :x | 1 to: size do: [ :y | array at: i put: (Array with: x with: y).
 														i:=i+1] ].
 	^ PMMatrix rows: array
 ]
@@ -272,7 +272,7 @@ PMTSNE >> computePairwiseAffinities [
 	1 to: n do: [ :i |
 		"Job progress gets updated every 10 rows"
 		(i % 10 = 0) ifTrue: [
-			job title: ('' join: {'Step 2/3: Computing joint probablity for point '. i asString. ' of '. n asString}).
+			job title: ('Step 2/3: Computing joint probablity for point {1} of {2}' format: (Array with: i with: n)).
 			job progress: (i/n).
 		 ].
 		
@@ -653,8 +653,9 @@ PMTSNE >> updateProgressWithError [
 			] ].
 		error := error sum sum ].
 	
-	job title: ('' join:
-		{'Step 3/3: Performing gradient descent '. iterations. '/'. maxIter. ' error = '. error}
+	job title: (
+		'Step 3/3: Performing gradient descent {1}/{2} error = {3}'
+			format: (Array with: iterations with: maxIter with: error)
 		).
 	job progress: iterations / maxIter.
 ]

--- a/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
@@ -51,21 +51,13 @@ PMAccuracyTest >> testAsArray [
 PMAccuracyTest >> testCalcDeviationsInMax [
 	| r c |
 	c := #(#(1 2 3) #(2 3 6)).
-	r := {(3 / 2).
-	(9 / 4).
-	4}.
+	r := Array with: (3 / 2) with: (9 / 4) with: 4.
 	self
 		assert: (a calcDeviations: r in: c max: false)
-		equals:
-			{(-100 / 3) asFloat.
-			(-100 / 9) asFloat.
-			-25}.
+		equals: (Array with: (-100 / 3) asFloat with: (-100 / 9) asFloat with: -25).
 	self
 		assert: (a calcDeviations: r in: c max: true)
-		equals:
-			{(100 / 3) asFloat.
-			(100 / 3) asFloat.
-			50}
+		equals: (Array with: (100 / 3) asFloat with: (100 / 3) asFloat with: 50)
 ]
 
 { #category : #tests }
@@ -112,11 +104,7 @@ PMAccuracyTest >> testDataTree [
 	s := a dataTree atPath: #('names' 'Fff' 'error').
 	self
 		assert: (s copyFrom: 1 to: 4)
-		equals:
-			{0.
-			Float infinity.
-			-100.0.
-			Float infinity negated}.
+		equals: (Array with: 0 with: Float infinity with: -100.0 with: Float infinity negated).
 	self assert: (s at: 5) isNaN
 ]
 
@@ -145,16 +133,13 @@ PMAccuracyTest >> testExtremeCollectionmax [
 	c := #(4 4 2).
 	self
 		assert: (a extremeCollection: c max: true)
-		equals: {Float infinity negated}.
+		equals: (Array with: Float infinity negated).
 	self
 		assert: (a extremeCollection: c max: false)
-		equals: {Float infinity}.
+		equals: (Array with: Float infinity).
 	self
-		assert: (a extremeCollection: {c} max: false)
-		equals:
-			{Float infinity.
-			Float infinity.
-			Float infinity}
+		assert: (a extremeCollection: (Array with: c) max: false)
+		equals: (Array with: Float infinity with: Float infinity with: Float infinity)
 ]
 
 { #category : #tests }
@@ -298,22 +283,24 @@ PMAccuracyTest >> testResultsKeyForAtPosition [
 	self
 		assert:
 			(a dataTree
-				atPath:
-					{'names'.
-					'Ccc'.
-					#(1).
-					(a resultsKeyFor: 'Ccc' AtPosition: 1).
-					'arguments'})
+				atPath: (
+					Array
+						with: 'names'
+						with: 'Ccc'
+						with: #(1)
+						with: (a resultsKeyFor: 'Ccc' AtPosition: 1)
+						with: 'arguments'))
 		equals: 1.
 	self
 		assert:
 			(a dataTree
-				atPath:
-					{'names'.
-					'Ccc'.
-					#(1).
-					(a resultsKeyFor: 'Ccc' AtPosition: 3).
-					'arguments'})
+				atPath: (
+					Array
+						with: 'names'
+						with: 'Ccc'
+						with: #(1)
+						with: (a resultsKeyFor: 'Ccc' AtPosition: 3)
+						with: 'arguments'))
 		equals: 0.9.
 	self assert: (a resultsKeyFor: 'Eee' AtPosition: 2) equals: #(1 3).
 	self

--- a/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
@@ -17,8 +17,7 @@ Class {
 PMAccuracyTestExample >> checkAaa [
 	self argument first
 		ifTrue: [ ^ #(1 1) ].
-	^ {(4 + (0.4 * Random new next)).
-	2}
+	^ Array with: (4 + (0.4 * Random new next)) with: 2
 ]
 
 { #category : #tests }
@@ -33,22 +32,17 @@ PMAccuracyTestExample >> checkCcc [
 
 { #category : #tests }
 PMAccuracyTestExample >> checkDdd [
-	^ {2 . 3} asOrderedCollection
+	^ OrderedCollection with: 2 with: 3
 ]
 
 { #category : #tests }
 PMAccuracyTestExample >> checkEee [
-	^ {self parameter first.
-	3}
+	^ Array with: self parameter first with: 3
 ]
 
 { #category : #tests }
 PMAccuracyTestExample >> checkFff [
-	^ {0.
-	0.
-	1.
-	0.
-	Float nan}
+	^ Array with: 0 with: 0 with: 1 with: 0 with: Float nan
 ]
 
 { #category : #private }
@@ -150,22 +144,20 @@ PMAccuracyTestExample >> tearDown [
 
 { #category : #private }
 PMAccuracyTestExample >> testGetterAaa [
-^{ 
-	self parameter. 
-	self argument. 
-	self resultsAt: 'Aaa'. 
-	self numberOfDifferentParametersAt: 'Aaa'. 
-	self numberOfDifferentResultsAt: 'Aaa'
- }
+^Array
+	with: self parameter
+	with: self argument
+	with: (self resultsAt: 'Aaa')
+	with: (self numberOfDifferentParametersAt: 'Aaa')
+	with: (self numberOfDifferentResultsAt: 'Aaa')
 ]
 
 { #category : #private }
 PMAccuracyTestExample >> testGetterBbb [
-^{ 
-	self parameter.
-	self argument.
-	self resultsAt: 'Bbb'.
-	self numberOfDifferentParametersAt: 'Bbb'.
-	self numberOfDifferentResultsAt: 'Bbb'
- }
+^Array
+	with: self parameter
+	with: self argument
+	with: (self resultsAt: 'Bbb')
+	with: (self numberOfDifferentParametersAt: 'Bbb')
+	with: (self numberOfDifferentResultsAt: 'Bbb')
 ]

--- a/src/Math-Tests-ArbitraryPrecisionFloat/PMArbitraryPrecisionFloatTest.class.st
+++ b/src/Math-Tests-ArbitraryPrecisionFloat/PMArbitraryPrecisionFloatTest.class.st
@@ -418,7 +418,11 @@ PMArbitraryPrecisionFloatTest >> testCosh [
 { #category : #'testing-arithmetic' }
 PMArbitraryPrecisionFloatTest >> testDivide [
 	| serie |
-	serie := {1. 2. 3. 5. 6. 7. 9. 10. 11. 12. 19. 243. 10 raisedTo: Float precision + 1. Float precision factorial. Float pi.}.
+	serie := #(1 2 3 5 6 7 9 10 11 12 19 243) asOrderedCollection
+			add: (10 raisedTo: Float precision + 1);
+			add: Float precision factorial;
+			add: Float pi;
+			asArray.
 	serie do: [:num |
 		| nf na |
 		nf := num asFloat.

--- a/src/Math-Tests-AutomaticDifferenciation/PMGradientAndHessianTest.class.st
+++ b/src/Math-Tests-AutomaticDifferenciation/PMGradientAndHessianTest.class.st
@@ -16,13 +16,7 @@ PMGradientAndHessianTest >> test [
 	h := PMHessian of: f.
 	r := #(0 0).
 	self assert: (g value: #(0 -2)) equals: r.
-	self
-		assert:
-			(g
-				value:
-					{1.
-					(-3 / 2)})
-		equals: r.
+	self assert: (g value: (Array with: 1 with: (-3 / 2))) equals: r.
 	self assert: (g value: #(-4 6)) equals: r.
 	self
 		assert: (h value: #(0 -2))

--- a/src/Math-Tests-FunctionFit/PMAnotherChromosomeManagerTest.class.st
+++ b/src/Math-Tests-FunctionFit/PMAnotherChromosomeManagerTest.class.st
@@ -192,7 +192,7 @@ PMAnotherChromosomeManagerTest >> testnumberOfHamersleyPoints [
 				numberOfHamersleyPoints: 9
 				dimension: 1
 				randomized: false)
-		equals: ((1 to: 9) collect: [ :i | {(i * (1 / 9))} ]).
+		equals: ((1 to: 9) collect: [ :i | Array with: i * (1 / 9) ]).
 	self
 		assert:
 			(PMAnotherChromosomeManager
@@ -200,42 +200,17 @@ PMAnotherChromosomeManagerTest >> testnumberOfHamersleyPoints [
 				dimension: 4
 				randomized: false)
 		equals:
-			{{(1 / 9).
-			(1 / 2).
-			(1 / 3).
-			(1 / 5)}.
-			{(2 / 9).
-			(1 / 4).
-			(2 / 3).
-			(2 / 5)}.
-			{(1 / 3).
-			(3 / 4).
-			(1 / 9).
-			(3 / 5)}.
-			{(4 / 9).
-			(1 / 8).
-			(4 / 9).
-			(4 / 5)}.
-			{(5 / 9).
-			(5 / 8).
-			(7 / 9).
-			(1 / 25)}.
-			{(2 / 3).
-			(3 / 8).
-			(2 / 9).
-			(6 / 25)}.
-			{(7 / 9).
-			(7 / 8).
-			(5 / 9).
-			(11 / 25)}.
-			{(8 / 9).
-			(1 / 16).
-			(8 / 9).
-			(16 / 25)}.
-			{1.
-			(9 / 16).
-			(1 / 27).
-			(21 / 25)}}.
+			(OrderedCollection new
+				add: (Array  with: (1 / 9) with: (1 / 2) with: (1 / 3) with: (1 / 5));
+				add: (Array  with: (2 / 9) with: (1 / 4) with: (2 / 3) with: (2 / 5));
+				add: (Array  with: (1 / 3) with: (3 / 4) with: (1 / 9) with: (3 / 5));
+				add: (Array  with: (4 / 9) with: (1 / 8) with: (4 / 9) with: (4 / 5));
+				add: (Array  with: (5 / 9) with: (5 / 8) with: (7 / 9) with: (1 / 25));
+				add: (Array  with: (2 / 3) with: (3 / 8) with: (2 / 9) with: (6 / 25));
+				add: (Array  with: (7 / 9) with: (7 / 8) with: (5 / 9) with: (11 / 25));
+				add: (Array  with: (8 / 9) with: (1 / 16) with: (8 / 9) with: (16 / 25));
+				add: (Array  with: 1 with: (9 / 16) with: (1 / 27) with: (21 / 25));
+				asArray).
 	rand := (PMAnotherChromosomeManager
 		numberOfHamersleyPoints: 3
 		dimension: 4

--- a/src/Math-Tests-FunctionFit/PMAnotherGeneticOptimizerTest.class.st
+++ b/src/Math-Tests-FunctionFit/PMAnotherGeneticOptimizerTest.class.st
@@ -146,17 +146,9 @@ PMAnotherGeneticOptimizerTest >> testaddPointAt [
 	b := go bestPoints.
 	self assert: b first position equals: #(0 1 0).
 	self assert: b first value equals: 1.
-	go
-		addPointAt:
-			{0.
-			Float nan.
-			0}.
+	go addPointAt: (Array with: 0 with: Float nan with: 0).
 	self assert: go bestPoints equals: b.
-	go
-		addPointAt:
-			{(0 - Float infinity).
-			0.
-			0}.
+	go addPointAt: (Array with: (0 - Float infinity) with: 0 with: 0).
 	self assert: go bestPoints equals: b.
 	go addPointAt: #(1 1 0).
 	b := go bestPoints.

--- a/src/Math-Tests-FunctionFit/PMErrorOfParameterFunctionTest.class.st
+++ b/src/Math-Tests-FunctionFit/PMErrorOfParameterFunctionTest.class.st
@@ -26,17 +26,11 @@ PMErrorOfParameterFunctionTest >> testErrorCollection [
 	f errorType: #squared.
 	self
 		assert: (f errorCollection: #(0 1))
-		equals:
-			{(1 / 4).
-			(4 / 9).
-			(9 / 16)}.
+		equals:(Array with: (1 / 4) with: (4 / 9) with: (9 / 16)).
 	f errorType: #abs.
 	self
 		assert: (f errorCollection: #(0 1))
-		equals:
-			{(1 / 2).
-			(2 / 3).
-			(3 / 4)}.
+		equals:(Array with: (1 / 2) with: (2 / 3) with: (3 / 4)).
 	f errorType: #median.
 	self assert: (f errorCollection: #(1 1)) equals: #(0 0 0)
 ]
@@ -64,7 +58,7 @@ PMErrorOfParameterFunctionTest >> testFunction [
 PMErrorOfParameterFunctionTest >> testPrint [
 |aStream  s|
 aStream :=ReadWriteStream with:''.
-f data:{(1@(1/2)). (2@(2/3)). (3@(3/4))} .
+f data:(Array with: (1@(1/2)) with: (2@(2/3)) with: (3@(3/4))).
 f printOn: aStream .
 s :=aStream contents .
 self assert: (s includesSubstring: 'a * x / (b + x)').
@@ -87,9 +81,7 @@ PMErrorOfParameterFunctionTest >> testQuartile [
 PMErrorOfParameterFunctionTest >> testRealValue [
 	f := PMErrorOfParameterFunction
 		function: [ :i :a | i + a ]
-		data:
-			{(1 @ 1).
-			(2 @ 2)}.
+		data: (Array with: 1 @ 1 with: 2 @ 2).
 	f errorType: #squared.
 	self assert: (f realValue: #(-2)) equals: 2.
 	f errorType: #abs.

--- a/src/Math-Tests-FunctionFit/PMGeneralFunctionFitTest.class.st
+++ b/src/Math-Tests-FunctionFit/PMGeneralFunctionFitTest.class.st
@@ -128,7 +128,7 @@ self assert: (s includesSubstring: '#(0.').
 PMGeneralFunctionFitTest >> testRelativeError [
 |r|
 f:=[ :x :a| a].
-col:={1@2. 2@6}.
+col:=Array with: 1@2 with: 2@6.
 fit:=PMGeneralFunctionFit function: f data: col minimumValues: -6 maximumValues: 6 .
 fit populationSize: 10.
 r :=fit evaluate first .

--- a/src/Math-Tests-KDTree/PMKDTreeTest.class.st
+++ b/src/Math-Tests-KDTree/PMKDTreeTest.class.st
@@ -48,7 +48,7 @@ PMKDTreeTest >> testIndexedKDTree1Dimension [
 	| m aVector aResult bResult |
 	m := (rand next: 200) collect: [:n | Array with: n].  "1-dimensional data, just some numbers"
 	self initializeTreeWith: m as: false.
-	1 to: 11 do: [:v | aVector := { 1 / v asFloat }.
+	1 to: 11 do: [:v | aVector := Array with: 1 / v asFloat.
 		aResult := stupid nnSearch: aVector i: 3.			"3 nearest numbers to aVector "
 		bResult := m atAll: ((tree nnSearch: aVector i: 3) collect: [:a | a first]).	
 		self equalityTest: aResult and: bResult].
@@ -86,13 +86,8 @@ PMKDTreeTest >> testIndexedKDTreeSimple [
 	1 to: 20 do: [ :v | 
 		n := 1 / v.
 		self
-			assert:
-				(aTree
-					nnSearch:
-						{n.
-						n}
-					i: 1)
-			equals: (bTree nnSearch: {n} i: 1) ]
+			assert: (aTree nnSearch: (Array with: n with: n) i: 1)
+			equals: (bTree nnSearch: (Array with: n) i: 1) ]
 ]
 
 { #category : #tests }
@@ -100,7 +95,7 @@ PMKDTreeTest >> testKDTree1Dimension [
 	| m aVector aResult bResult |
 	m :=(rand next: 200) collect: [:n | Array with: n].	"1-dimensional data, just some numbers"
 	self initializeTreeWith: m as: true .
-	1 to: 11 do: [:v | aVector := { 1 / v asFloat }.
+	1 to: 11 do: [:v | aVector := Array with: 1 / v asFloat.
 		aResult := stupid nnSearch: aVector i: 3.				"3 nearest numbers to aVector "
 		bResult := tree nnSearch: aVector i: 3.							
 		self equalityTest: aResult and: bResult].
@@ -111,7 +106,7 @@ PMKDTreeTest >> testKDTree1DimensionIntegers [
 	| m aVector aResult bResult |
 	m := (1 to: 20) collect: [:index | Array with: (rand nextInt: 10)].	"only integers, obviously with multiples. test distances because the nearest neighbours are not necessarily the same"
 	self initializeTreeWith: m as: true.
-	0 to: 11 do:[:v | aVector :={v}.
+	0 to: 11 do:[:v | aVector := Array with: v.
 		aResult :=(aVector first - (stupid nnSearch: aVector i: 3)) abs.		"distances between 3 nearest numbers and aVector "
 		bResult :=(aVector first - (tree nnSearch: aVector i: 3)) abs.		"distances using KDTree"
 		self equalityTest: aResult and: bResult ]  .
@@ -158,20 +153,14 @@ PMKDTreeTest >> testPMVectorCompatibility [
 		ifNil: [ ^ self skip: 'necessary PM package not loaded' ].
 	aVector := #(0) asPMVector.
 	bVector := #(-2.0) asPMVector.
-	r := {aVector.
-	#(-5.0) asPMVector.
-	bVector} asPMVector.
+	r := (Array with: aVector with: #(-5.0) asPMVector with:  bVector) asPMVector.
 	self initializeTreeWith: r as: true.
 	self
 		assert: (tree nnSearch: bVector i: 2)
-		equals:
-			{bVector.
-			aVector}.
+		equals: (Array with: bVector with: aVector).
 	self
 		assert: (stupid nnSearch: bVector i: 2)
-		equals:
-			{bVector.
-			aVector}.
+		equals: (Array with: bVector with: aVector).
 	self initializeTreeWith: r as: false.
 	r := tree nnSearch: bVector i: 2.
 	self assert: r first equals: #(3 0.0).

--- a/src/Math-Tests-KDTree/PMNNStoreTest.class.st
+++ b/src/Math-Tests-KDTree/PMNNStoreTest.class.st
@@ -74,12 +74,10 @@ PMNNStoreTest >> testExtremeCase [
 	n add: #(1 1).	"adding should also always be possible, although it will not be added in this case"
 	self deny: n maxDistance = 1.
 	n
-		add:
-			{(0 - Float infinity).
-			1}.	"and this extreme case too."
+		add: (Array with: (0 - Float infinity) with: 1).	"and this extreme case too."
 	self assert: n isEmpty.
 	self assert: n data equals: #().
-	self should: [ n add: {nil . 1} ] raise: Error	"but this should always raise an error (not only in NNStores with size 0), also in subclasses, otherwise one can have strange bugs"
+	self should: [ n add: (Array with: nil with: 1) ] raise: Error	"but this should always raise an error (not only in NNStores with size 0), also in subclasses, otherwise one can have strange bugs"
 ]
 
 { #category : #tests }
@@ -183,7 +181,7 @@ PMNNStoreTest >> testWithAll [
 	n sortFor: nil.	"calling sortFor: is necessary with withAll:"
 	self assert: n data equals: #(2 4 5).
 	self assert: n isFull.
-	n add: {3 . 6}.	"one has to be a bit carefull when one uses 
+	n add: #(3 6).	"one has to be a bit carefull when one uses 
 				 NNStore withAll:, as sortfor: changes this data. 
 				 n add: #(3 6) is not possible here!"
 	self assert: n data equals: #(2 6 4).

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -238,7 +238,7 @@ PMMatrixTest >> testMatrixCloseToPrecision [
 { #category : #comparing }
 PMMatrixTest >> testMatrixCos [
 	| a |
-	a := PMMatrix rows: {{Float pi. Float pi.}. {0. 0.}}.
+	a := PMMatrix rows: (Array with: (Array with: Float pi with: Float pi) with: #(0 0)).
 	self assert: a cos equals: (PMMatrix rows:#((-1 -1) (1 1)))
 ]
 

--- a/src/Math-Tests-Matrix/PMSingularValueDecompositionTest.class.st
+++ b/src/Math-Tests-Matrix/PMSingularValueDecompositionTest.class.st
@@ -96,18 +96,21 @@ PMSingularValueDecompositionTest >> loadExample3 [
 		(-1 1 0)
 		(0 -1 1)).
 		
-	actualU := PMMatrix rows: { 
-		{ -1 / (2 sqrt) . 1 / (2 sqrt) } .
-		{ 1 / (2 sqrt) . 1 / (2 sqrt) } }.
+	actualU := PMMatrix rows: (
+		Array
+			with: (Array with: -1 / (2 sqrt) with: 1 / (2 sqrt))
+			with: (Array with: 1 / (2 sqrt) with: 1 / (2 sqrt)) ).
 		
-	actualV := PMMatrix rows: { 
-		{ 1 / (6 sqrt) . -1 / (2 sqrt) . 1 / (3 sqrt) } .
-		{ -2 / (6 sqrt) . 0 . 1 / (3 sqrt) } .
-		{ 1 / (6 sqrt) . 1 / (2 sqrt) . 1 / (3 sqrt) } }.
+	actualV := PMMatrix rows: (
+		Array
+			with: (Array with: 1 / (6 sqrt) with: -1 / (2 sqrt) with: 1 / (3 sqrt))
+			with: (Array with: -2 / (6 sqrt) with: 0 with: 1 / (3 sqrt))
+			with: (Array with: 1 / (6 sqrt) with: 1 / (2 sqrt) with: 1 / (3 sqrt)) ).
 		
-	actualS := PMMatrix rows: {
-		{ 3 sqrt . 0 . 0} .
-		{0 . 1 . 0}}.
+	actualS := PMMatrix rows: (
+		Array
+			with: (Array with: 3 sqrt with: 0 with: 0)
+			with: (Array with: 0 with: 1 with: 0) ).
 ]
 
 { #category : #'as yet unclassified' }
@@ -126,18 +129,20 @@ PMSingularValueDecompositionTest >> loadExample4 [
 		(0 0 0 -1)
 		(1 0 0 0)).
 		
-	actualV := PMMatrix rows: { 
-		{ 0 . 0 . 0.2 sqrt . 0 . -1 * (0.8 sqrt) } .
-		{ 1 . 0 . 0 . 0 . 0 } .
-		{ 0 . 1 . 0 . 0 . 0 } .
-		{ 0 . 0 . 0 . 1 . 0 } .
-		{ 0 . 0 . 0.8 sqrt . 0 . 0.2 sqrt } }.
+	actualV := PMMatrix rows: (Array
+		with: ( Array with: 0 with: 0 with: 0.2 sqrt with: 0 with: -1 * (0.8 sqrt))
+		with: ( Array with: 1 with: 0 with: 0 with: 0 with: 0)
+		with: ( Array with: 0 with: 1 with: 0 with: 0 with: 0)
+		with: ( Array with: 0 with: 0 with: 0 with: 1 with: 0)
+		with: ( Array with: 0 with: 0 with: 0.8 sqrt with: 0 with: 0.2 sqrt)
+	).
 		
-	actualS := PMMatrix rows: {
-		{ 2 . 0 . 0 . 0 . 0 } .
-		{ 0 . 3 . 0 . 0 . 0 } .
-		{ 0 . 0 . 5 sqrt . 0 . 0 } .
-		{ 0 . 0 . 0 . 0 . 0 } }.
+	actualS := PMMatrix rows: (Array
+		with: (Array with: 2 with: 0 with: 0 with: 0 with: 0)
+		with: (Array with: 0 with: 3 with: 0 with: 0 with: 0)
+		with: (Array with: 0 with: 0 with: 5 sqrt with: 0 with: 0)
+		with: (Array with: 0 with: 0 with: 0 with: 0 with: 0)
+	)
 ]
 
 { #category : #initialization }

--- a/src/Math-Tests-Numerical/PMGeneticOptimizerBugsTest.class.st
+++ b/src/Math-Tests-Numerical/PMGeneticOptimizerBugsTest.class.st
@@ -33,7 +33,7 @@ PMGeneticOptimizerBugsTest >> testBug2 [
 | r |
 optimizer addPointAt: #(2 3).
 "i add a nan by hand here,which in a way doesnt make sense, just to get a nan result for function, but with a more complicated function it is perfectly possible for the optimizer to produce nan's by itself!"
-optimizer addPointAt: {Float nan. 3}.
+optimizer addPointAt: (Array with: Float nan with: 3).
 "if you inspect r here you will see that a _single nan result can _completely throw off the ga calculations"
 r:=optimizer randomScale.
 self deny: r first isNaN.

--- a/src/Math-Tests-Permutation/PMPermutationTest.class.st
+++ b/src/Math-Tests-Permutation/PMPermutationTest.class.st
@@ -11,7 +11,7 @@ PMPermutationTest >> testAllOfSize [
 	self assert: (PMPermutation allOfSize: 0) equals: #().
 	self
 		assert: (PMPermutation allOfSize: 1)
-		equals: {(PMPermutation identity: 1)}.
+		equals: (Array with: (PMPermutation identity: 1)).
 	"odd"
 	p := PMPermutation allOfSize: 3.
 	self assert: p size equals: 3 factorial.
@@ -122,19 +122,25 @@ PMPermutationTest >> testFromCycles [
 { #category : #'class tests' }
 PMPermutationTest >> testGenerator [
 |g c|
-g:=PMPermutation generator: {PMPermutation size: 7 shift: 2}.
+g:=PMPermutation generator: (Array with: (PMPermutation size: 7 shift: 2)).
 g do:[:p|self assert: p class equals:PMPermutation].
 self assert: g size equals: 7.
 self assert: (g includes: (PMPermutation identity: 7)) .
-g:=PMPermutation generator: {PMPermutation size: 6 shift: 2. (PMPermutation identity: 6)reverse}.
+g:=PMPermutation generator: (Array
+	with: (PMPermutation size: 6 shift: 2)
+	with: (PMPermutation identity: 6)reverse).
 self assert: g size equals: 6.
 self assert: (g includes: (PMPermutation identity: 6)) .
 
-g:=PMPermutation generator: { PMPermutation fromCycles: #((2 3 4 5)).PMPermutation fromCycles: #((1 2))}.
+g:=PMPermutation generator: (Array
+	with: (PMPermutation fromCycles: #((2 3 4 5)))
+	with: (PMPermutation fromCycles: #((1 2)))).
 c:=(PMPermutation allOfSize: 5).
 self assert: g asSet equals: c asSet.
 self assert: g size equals: c size.
-g:=PMPermutation generator: { PMPermutation fromCycles: #((3 4 5)).PMPermutation fromCycles: #((1 2 3))}.
+g:=PMPermutation generator: (Array
+	with: (PMPermutation fromCycles: #((3 4 5)))
+	with: (PMPermutation fromCycles: #((1 2 3)))).
 c:=c select:[:p|p even].
 self assert: g asSet equals: c asSet.
 self assert: g size equals: c size.

--- a/src/Math-Tests-Quantile/PMQuantileTest.class.st
+++ b/src/Math-Tests-Quantile/PMQuantileTest.class.st
@@ -30,11 +30,7 @@ PMQuantileTest >> setUp [
 	c := #(1 3 2 4 5) asSortedCollection.
 	d := #(1 3 2 4 5 6) asSortedCollection.
 	b := #(2 4 5 7 8 9 10 12 15 16 18) asSortedCollection.
-	q := {0.
-	(1 / 4).
-	(1 / 2).
-	(3 / 4).
-	1}
+	q := Array with: 0 with: (1 / 4) with: (1 / 2) with: (3 / 4) with: 1
 ]
 
 { #category : #tests }
@@ -58,11 +54,7 @@ PMQuantileTest >> testExtremeCase [
 		assert:
 			(a
 				quantile: 0
-				withProbs:
-					{0.5.
-					0.5.
-					(1 / 2).
-					(1 / 2)})
+				withProbs: (Array with: 0.5 with: 0.5 with: (1 / 2) with: (1 / 2)))
 		equals: 1
 ]
 
@@ -70,12 +62,7 @@ PMQuantileTest >> testExtremeCase [
 PMQuantileTest >> testQuantileA [
 	self
 		assert: (self resultCollect: a method: #modeBased)
-		equals:
-			{1.
-			(7 / 4).
-			(5 / 2).
-			(13 / 4).
-			4}.
+		equals: (Array with: 1 with: (7 / 4) with: (5 / 2) with: (13 / 4) with: 4).
 	self
 		assert: (self resultCollect: a method: #inverseCDF)
 		equals: #(1 1 2 3 4).
@@ -87,36 +74,16 @@ PMQuantileTest >> testQuantileA [
 		equals: #(1 1 2 3 4).
 	self
 		assert: (self resultCollect: a method: #hydrologist)
-		equals:
-			{1.
-			(3 / 2).
-			(5 / 2).
-			(7 / 2).
-			4}.
+		equals: (Array with: 1 with: (3 / 2) with: (5 / 2) with: (7 / 2) with:  4).
 	self
 		assert: (self resultCollect: a method: #weibull)
-		equals:
-			{1.
-			(5 / 4).
-			(5 / 2).
-			(15 / 4).
-			4}.
+		equals: (Array with: 1 with: (5 / 4) with: (5 / 2) with: (15 / 4) with:  4).
 	self
 		assert: (self resultCollect: a method: #medianBased)
-		equals:
-			{1.
-			(17 / 12).
-			(5 / 2).
-			(43 / 12).
-			4}.
+		equals: (Array with: 1 with: (17 / 12) with: (5 / 2) with: (43 / 12) with:  4).
 	self
 		assert: (self resultCollect: a method: #normalDistribution)
-		equals:
-			{1.
-			(23 / 16).
-			(5 / 2).
-			(57 / 16).
-			4}.
+		equals: (Array with: 1 with: (23 / 16) with: (5 / 2) with: (57 / 16) with: 4).
 	self assert: (a quantile: 1 / 4) equals: 7 / 4.
 	self assert: a interQuartileRange equals: 2
 ]
@@ -127,12 +94,7 @@ PMQuantileTest >> testQuantileB [
 
 	self
 		assert: (self resultCollect: b method: #modeBased)
-		equals:
-			{2.
-			6.
-			9.
-			(27 / 2).
-			18}.
+		equals: (Array with: 2 with: 6 with: 9 with: (27 / 2) with: 18).
 	self
 		assert: (self resultCollect: b method: #inverseCDF)
 		equals: #(2 5 9 15 18).
@@ -141,39 +103,19 @@ PMQuantileTest >> testQuantileB [
 		equals: #(2 5 9 12 18).
 	self
 		assert: (self resultCollect: b method: #california)
-		equals:
-			{2.
-			(19 / 4).
-			(17 / 2).
-			(51 / 4).
-			18}.
+		equals: (Array with: 2 with: (19 / 4) with: (17 / 2) with: (51 / 4) with: 18).
 	self
 		assert: (self resultCollect: b method: #hydrologist)
-		equals:
-			{2.
-			(11 / 2).
-			9.
-			(57 / 4).
-			18}.
+		equals: (Array with: 2 with: (11 / 2) with: 9 with: (57 / 4) with: 18).
 	self
 		assert: (self resultCollect: b method: #weibull)
 		equals: #(2 5 9 15 18).
 	self
 		assert: (self resultCollect: b method: #medianBased)
-		equals:
-			{2.
-			(16 / 3).
-			9.
-			(29 / 2).
-			18}.
+		equals: (Array with: 2 with: (16 / 3) with: 9 with: (29 / 2) with: 18).
 	self
 		assert: (self resultCollect: b method: #normalDistribution)
-		equals:
-			{2.
-			(43 / 8).
-			9.
-			(231 / 16).
-			18}.
+		equals: (Array with: 2 with: (43 / 8) with: 9 with: (231 / 16) with: 18).
 	self assert: (b quantile: 1 / 4) equals: 6.
 	self assert: b interQuartileRange equals: 35 / 4
 ]
@@ -194,41 +136,17 @@ PMQuantileTest >> testQuantileC [
 		equals: #(1 1 3 4 5).
 	self
 		assert: (self resultCollect: c method: #california)
-		equals:
-			{1.
-			(5 / 4).
-			(5 / 2).
-			(15 / 4).
-			5}.
+		equals: (Array with: 1 with: (5 / 4) with: (5 / 2) with: (15 / 4) with: 5).
 	self
 		assert: (self resultCollect: c method: #hydrologist)
-		equals:
-			{1.
-			(7 / 4).
-			3.
-			(17 / 4).
-			5}.
+		equals: (Array with: 1 with: (7 / 4) with: 3 with: (17 / 4) with: 5).
 	self
 		assert: (self resultCollect: c method: #weibull)
-		equals:
-			{1.
-			(3 / 2).
-			3.
-			(9 / 2).
-			5}.
+		equals: (Array with: 1 with: (3 / 2) with: 3 with: (9 / 2) with: 5).
 	self
 		assert: (self resultCollect: c method: #medianBased)
-		equals:
-			{1.
-			(5 / 3).
-			3.
-			(13 / 3).
-			5}.
-	r := {1.
-	(27 / 16).
-	3.
-	(69 / 16).
-	5}.
+		equals: (Array with: 1 with: (5 / 3) with: 3 with: (13 / 3) with: 5).
+	r := Array with: 1 with: (27 / 16) with: 3 with: (69 / 16) with: 5.
 	self
 		assert: (self resultCollect: c method: #normalDistribution)
 		equals: r.
@@ -236,11 +154,7 @@ PMQuantileTest >> testQuantileC [
 		assert:
 			(self
 				resultCollect: c
-				withProbs:
-					{(3 / 8).
-					(1 / 4).
-					0.
-					1})
+				withProbs: (Array with: (3 / 8) with: (1 / 4) with: 0 with: 1))
 		equals: r.
 	self assert: c interQuartileRange equals: 5 / 2
 ]
@@ -251,12 +165,7 @@ PMQuantileTest >> testQuantileD [
 
 	self
 		assert: (self resultCollect: d method: #modeBased)
-		equals:
-			{1.
-			(9 / 4).
-			(7 / 2).
-			(19 / 4).
-			6}.
+		equals: (Array with: 1 with: (9 / 4) with: (7 / 2) with: (19 / 4) with: 6).
 	self
 		assert: (self resultCollect: d method: #inverseCDF)
 		equals: #(1 2 3 5 6).
@@ -265,43 +174,18 @@ PMQuantileTest >> testQuantileD [
 		equals: #(1 2 3 5 6).
 	self
 		assert: (self resultCollect: d method: #california)
-		equals:
-			{1.
-			(3 / 2).
-			3.
-			(9 / 2).
-			6}.
+		equals: (Array with: 1 with: (3 / 2) with: 3 with: (9 / 2) with: 6).
 	self
 		assert: (self resultCollect: d method: #hydrologist)
-		equals:
-			{1.
-			2.
-			(7 / 2).
-			5.
-			6}.
+		equals: (Array with: 1 with: 2 with: (7 / 2) with: 5 with: 6).
 	self
 		assert: (self resultCollect: d method: #weibull)
-		equals:
-			{1.
-			(7 / 4).
-			(7 / 2).
-			(21 / 4).
-			6}.
+		equals: (Array with: 1 with: (7 / 4) with: (7 / 2) with: (21 / 4) with: 6).
 	self
 		assert: (self resultCollect: d method: #medianBased)
-		equals:
-			{1.
-			(23 / 12).
-			(7 / 2).
-			(61 / 12).
-			6}.
+		equals: (Array with: 1 with: (23 / 12) with: (7 / 2) with: (61 / 12) with: 6).
 	self
 		assert: (self resultCollect: d method: #normalDistribution)
-		equals:
-			{1.
-			(31 / 16).
-			(7 / 2).
-			(81 / 16).
-			6}.
+		equals: (Array with: 1 with: (31 / 16) with: (7 / 2) with: (81 / 16) with: 6).
 	self assert: d interQuartileRange equals: 3
 ]

--- a/src/Math-Tests-TSNE/PMTSNETest.class.st
+++ b/src/Math-Tests-TSNE/PMTSNETest.class.st
@@ -14,7 +14,10 @@ PMTSNETest >> testComputePValues [
 	t := (PMTSNE new)
 		x: (PMMatrix rows: #(#(1 2 3) #(4 5 6) #(7 8 9)));
 		perplexity: 30.0.
-	self assert: t computePValues closeTo: (PMMatrix rows: {{0. 2/3. 2/3.}. {2/3. 0. 2/3}. {2/3. 2/3. 0.}})
+	self assert: t computePValues closeTo: (PMMatrix rows: (Array
+		with: (Array with: 0 with: 2/3 with: 2/3) 
+		with: (Array with: 2/3 with: 0 with: 2/3) 
+		with: (Array with: 2/3 with: 2/3 with: 0)))
 ]
 
 { #category : #tests }
@@ -59,7 +62,7 @@ PMTSNETest >> testEntropyOfAndPRowWithBeta [
 	pVector := PMVector new: (distanceVector size).	
 	entropy := PMTSNE entropyOf: distanceVector andPRow: pVector withBeta: 2.0.
 	self assert: entropy closeTo: 0.003020119571023052.
-	self assert: pVector closeTo: { 0.99966454 . 0.00000011 . 0.00033535 } asPMVector.
+	self assert: pVector closeTo: (Array with: 0.99966454 with: 0.00000011 with: 0.00033535) asPMVector.
 	
 ]
 


### PR DESCRIPTION
closes #159 
Replaced curly braces with Arrays, explicit in most cases.
I don't know if using `#with:with:with:with:with:with:` is portable, but it's easily fixable.