### PR TITLE
[Issue 154] Refactor PMAccuracy testDataTree method

### DIFF
--- a/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
@@ -19,15 +19,16 @@ PMAccuracyTest >> initialize [
 ]
 
 { #category : #running }
-PMAccuracyTest >> setUp [ 
+PMAccuracyTest >> setUp [
+	super setUp.
 	a := PMAccuracyTestExample new.
-	PMAccuracyTestExample decimalPlaces: 3.
+	PMAccuracyTestExample decimalPlaces: 3
 ]
 
 { #category : #running }
-PMAccuracyTest >> tearDown [ 
+PMAccuracyTest >> tearDown [
 	PMAccuracyTestExample decimalPlaces: dp.
-
+	super tearDown.
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
@@ -75,40 +75,6 @@ PMAccuracyTest >> testCalcErrorOfRealResult [
 ]
 
 { #category : #tests }
-PMAccuracyTest >> testDataTree [
-	| s |
-	a run.
-	self assert: (a dataTree atPath: #('iterations')) equals: 1.
-	self
-		assert: (a dataTree atPath: #('names' 'data'))
-		equals: #('Aaa' 'Bbb' 'Ccc' 'Ddd' 'Eee' 'Fff').
-	self
-		assert: (a dataTree atPath: #('names' 'Aaa' #(1 2) #(4 4)))
-		equals:
-			(KeyedTree new
-				at: 'arguments' put: true;
-				at: 'data' put: #(#(1 1));
-				at: 'error' put: #(300.0 300.0);
-				at: 'expected result' put: #(4 4);
-				at: 'result' put: #(1 1);
-				at: 'type' put: 'result';
-				yourself).
-	self
-		assert: (a dataTree atPath: #('names' 'Aaa' 'data'))
-		equals: #(#(1 2) #(3 2.8888)).
-	self
-		assert: (a dataTree atPath: #('names' 'Bbb' #(3) 'data'))
-		equals: #(#(2) #(3)).
-	s := a dataTree atPath: #('names' 'Ccc' #(3)).
-	self assert: s keys size equals: 5.
-	s := a dataTree atPath: #('names' 'Fff' 'error').
-	self
-		assert: (s copyFrom: 1 to: 4)
-		equals: (Array with: 0 with: Float infinity with: -100.0 with: Float infinity negated).
-	self assert: (s at: 5) isNaN
-]
-
-{ #category : #tests }
 PMAccuracyTest >> testDecimalPlaces [
 	self assert: a class decimalPlaces equals: 3.
 	a class decimalPlaces: 2.

--- a/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
+++ b/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
@@ -1,0 +1,70 @@
+"
+Class Name: PMDataTreeTest 
+
+Responsibility: exercising the PMAccuracyTestExample's 
+dataTree message
+
+Collaborators: PMAccuracyTestExample 
+"
+Class {
+	#name : #PMDataTreeTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'dp',
+		'a'
+	],
+	#category : #'Math-Tests-Accuracy'
+}
+
+{ #category : #initialization }
+PMDataTreeTest >> initialize [ 
+	super initialize.
+	dp := PMAccuracyTestExample decimalPlaces
+]
+
+{ #category : #running }
+PMDataTreeTest >> setUp [ 
+	super setUp.
+	a := PMAccuracyTestExample new.
+	PMAccuracyTestExample decimalPlaces: 3.
+]
+
+{ #category : #running }
+PMDataTreeTest >> tearDown [ 
+	super tearDown.
+	PMAccuracyTestExample decimalPlaces: dp.
+]
+
+{ #category : #tests }
+PMDataTreeTest >> testDataTree [
+	| s |
+	a run.
+	self assert: (a dataTree atPath: #('iterations')) equals: 1.
+	self
+		assert: (a dataTree atPath: #('names' 'data'))
+		equals: #('Aaa' 'Bbb' 'Ccc' 'Ddd' 'Eee' 'Fff').
+	self
+		assert: (a dataTree atPath: #('names' 'Aaa' #(1 2) #(4 4)))
+		equals:
+			(KeyedTree new
+				at: 'arguments' put: true;
+				at: 'data' put: #(#(1 1));
+				at: 'error' put: #(300.0 300.0);
+				at: 'expected result' put: #(4 4);
+				at: 'result' put: #(1 1);
+				at: 'type' put: 'result';
+				yourself).
+	self
+		assert: (a dataTree atPath: #('names' 'Aaa' 'data'))
+		equals: #(#(1 2) #(3 2.8888)).
+	self
+		assert: (a dataTree atPath: #('names' 'Bbb' #(3) 'data'))
+		equals: #(#(2) #(3)).
+	s := a dataTree atPath: #('names' 'Ccc' #(3)).
+	self assert: s keys size equals: 5.
+	s := a dataTree atPath: #('names' 'Fff' 'error').
+	self
+		assert: (s copyFrom: 1 to: 4)
+		equals: (Array with: 0 with: Float infinity with: -100.0 with: Float infinity negated).
+	self assert: (s at: 5) isNaN
+]

--- a/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
+++ b/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
@@ -58,7 +58,8 @@ PMDataTreeTest >> testDataTree [
 PMDataTreeTest >> testThatKeyedTreeContainsArgsDataErrorResultsAndType [
 	"SMELL - it's not easy to determine the true purpose of the
 	test and, perhaps with the exception of the 'expected result', 
-	how input leads to the output.
+	how input leads to the output. The test also contains many
+	'magic' numbers.
 	"
 	a run.
 	self

--- a/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
+++ b/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
@@ -39,7 +39,6 @@ PMDataTreeTest >> tearDown [
 PMDataTreeTest >> testDataTree [
 	| s |
 	a run.
-	self assert: (a dataTree atPath: #('iterations')) equals: 1.
 	self
 		assert: (a dataTree atPath: #('names' 'data'))
 		equals: #('Aaa' 'Bbb' 'Ccc' 'Ddd' 'Eee' 'Fff').
@@ -67,4 +66,11 @@ PMDataTreeTest >> testDataTree [
 		assert: (s copyFrom: 1 to: 4)
 		equals: (Array with: 0 with: Float infinity with: -100.0 with: Float infinity negated).
 	self assert: (s at: 5) isNaN
+]
+
+{ #category : #tests }
+PMDataTreeTest >> testThatRunIncrementsTheNumberOfIterations [
+	"SMELL - we're really testing run, it seems."
+	a run.
+	self assert: (a dataTree atPath: #('iterations')) equals: 1.
 ]

--- a/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
+++ b/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
@@ -40,9 +40,6 @@ PMDataTreeTest >> testDataTree [
 	| s |
 	a run.
 	self
-		assert: (a dataTree atPath: #('names' 'data'))
-		equals: #('Aaa' 'Bbb' 'Ccc' 'Ddd' 'Eee' 'Fff').
-	self
 		assert: (a dataTree atPath: #('names' 'Aaa' #(1 2) #(4 4)))
 		equals:
 			(KeyedTree new
@@ -73,4 +70,12 @@ PMDataTreeTest >> testThatRunIncrementsTheNumberOfIterations [
 	"SMELL - we're really testing run, it seems."
 	a run.
 	self assert: (a dataTree atPath: #('iterations')) equals: 1.
+]
+
+{ #category : #tests }
+PMDataTreeTest >> testThatTheNamesAreInitialisationKeys [
+	a run.
+	self
+		assert: (a dataTree atPath: #('names' 'data'))
+		equals: #('Aaa' 'Bbb' 'Ccc' 'Ddd' 'Eee' 'Fff')
 ]

--- a/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
+++ b/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
@@ -56,6 +56,10 @@ PMDataTreeTest >> testDataTree [
 
 { #category : #tests }
 PMDataTreeTest >> testThatKeyedTreeContainsArgsDataErrorResultsAndType [
+	"SMELL - it's not easy to determine the true purpose of the
+	test and, perhaps with the exception of the 'expected result', 
+	how input leads to the output.
+	"
 	a run.
 	self
 		assert: (a dataTree atPath: #('names' 'Aaa' #(1 2) #(4 4)))

--- a/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
+++ b/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
@@ -39,9 +39,6 @@ PMDataTreeTest >> tearDown [
 PMDataTreeTest >> testDataTree [
 	| s |
 	a run.
-	self
-		assert: (a dataTree atPath: #('names' 'Bbb' #(3) 'data'))
-		equals: #(#(2) #(3)).
 	s := a dataTree atPath: #('names' 'Ccc' #(3)).
 	self assert: s keys size equals: 5.
 	s := a dataTree atPath: #('names' 'Fff' 'error').
@@ -88,6 +85,20 @@ PMDataTreeTest >> testThatRunIncrementsTheNumberOfIterations [
 	"SMELL - we're really testing run, it seems."
 	a run.
 	self assert: (a dataTree atPath: #('iterations')) equals: 1.
+]
+
+{ #category : #tests }
+PMDataTreeTest >> testThatTheDataForBbbIsTheDefaultResult [
+	"SMELL - magic number. This may be coincidental, but the 
+	expected result in this test is that set in 
+	PMAccuracyTestExample's initialize method.
+	"
+	| defaultResultAtInitialisation |
+	a run.
+	defaultResultAtInitialisation := #(#(2) #(3)).
+	self
+		assert: (a dataTree atPath: #('names' 'Bbb' #(3) 'data'))
+		equals: defaultResultAtInitialisation
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
+++ b/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
@@ -31,8 +31,8 @@ PMDataTreeTest >> setUp [
 
 { #category : #running }
 PMDataTreeTest >> tearDown [ 
-	super tearDown.
 	PMAccuracyTestExample decimalPlaces: dp.
+	super tearDown.
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
+++ b/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
@@ -40,17 +40,6 @@ PMDataTreeTest >> testDataTree [
 	| s |
 	a run.
 	self
-		assert: (a dataTree atPath: #('names' 'Aaa' #(1 2) #(4 4)))
-		equals:
-			(KeyedTree new
-				at: 'arguments' put: true;
-				at: 'data' put: #(#(1 1));
-				at: 'error' put: #(300.0 300.0);
-				at: 'expected result' put: #(4 4);
-				at: 'result' put: #(1 1);
-				at: 'type' put: 'result';
-				yourself).
-	self
 		assert: (a dataTree atPath: #('names' 'Aaa' 'data'))
 		equals: #(#(1 2) #(3 2.8888)).
 	self
@@ -63,6 +52,22 @@ PMDataTreeTest >> testDataTree [
 		assert: (s copyFrom: 1 to: 4)
 		equals: (Array with: 0 with: Float infinity with: -100.0 with: Float infinity negated).
 	self assert: (s at: 5) isNaN
+]
+
+{ #category : #tests }
+PMDataTreeTest >> testThatKeyedTreeContainsArgsDataErrorResultsAndType [
+	a run.
+	self
+		assert: (a dataTree atPath: #('names' 'Aaa' #(1 2) #(4 4)))
+		equals:
+			(KeyedTree new
+				at: 'arguments' put: true;
+				at: 'data' put: #(#(1 1));
+				at: 'error' put: #(300.0 300.0);
+				at: 'expected result' put: #(4 4);
+				at: 'result' put: #(1 1);
+				at: 'type' put: 'result';
+				yourself)
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
+++ b/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
@@ -37,15 +37,15 @@ PMDataTreeTest >> tearDown [
 
 { #category : #tests }
 PMDataTreeTest >> testDataTree [
-	| s |
+	| keyedTree |
 	a run.
-	s := a dataTree atPath: #('names' 'Ccc' #(3)).
-	self assert: s keys size equals: 5.
-	s := a dataTree atPath: #('names' 'Fff' 'error').
+	keyedTree := a dataTree atPath: #('names' 'Ccc' #(3)).
+	self assert: keyedTree keys size equals: 5.
+	keyedTree := a dataTree atPath: #('names' 'Fff' 'error').
 	self
-		assert: (s copyFrom: 1 to: 4)
+		assert: (keyedTree copyFrom: 1 to: 4)
 		equals: (Array with: 0 with: Float infinity with: -100.0 with: Float infinity negated).
-	self assert: (s at: 5) isNaN
+	self assert: (keyedTree at: 5) isNaN
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
+++ b/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
@@ -37,16 +37,10 @@ PMDataTreeTest >> tearDown [
 
 { #category : #tests }
 PMDataTreeTest >> testDataTree [
-	| keyedTree error |
+	| keyedTree |
 	a run.
 	keyedTree := a dataTree atPath: #('names' 'Ccc' #(3)).
 	self assert: keyedTree keys size equals: 5.
-	
-	error := a dataTree atPath: #('names' 'Fff' 'error').
-	self
-		assert: (error copyFrom: 1 to: 4)
-		equals: (Array with: 0 with: Float infinity with: -100.0 with: Float infinity negated).
-	self assert: (error at: 5) isNaN.
 ]
 
 { #category : #tests }
@@ -100,6 +94,17 @@ PMDataTreeTest >> testThatTheDataForBbbIsTheDefaultResult [
 	self
 		assert: (a dataTree atPath: #('names' 'Bbb' #(3) 'data'))
 		equals: defaultResultAtInitialisation
+]
+
+{ #category : #tests }
+PMDataTreeTest >> testThatTheErrorForFffIsCorrect [
+	| error |
+	a run.
+	error := a dataTree atPath: #('names' 'Fff' 'error').
+	self
+		assert: (error copyFrom: 1 to: 4)
+		equals: (Array with: 0 with: Float infinity with: -100.0 with: Float infinity negated).
+	self assert: (error at: 5) isNaN.
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
+++ b/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
@@ -37,15 +37,16 @@ PMDataTreeTest >> tearDown [
 
 { #category : #tests }
 PMDataTreeTest >> testDataTree [
-	| keyedTree |
+	| keyedTree error |
 	a run.
 	keyedTree := a dataTree atPath: #('names' 'Ccc' #(3)).
 	self assert: keyedTree keys size equals: 5.
-	keyedTree := a dataTree atPath: #('names' 'Fff' 'error').
+	
+	error := a dataTree atPath: #('names' 'Fff' 'error').
 	self
-		assert: (keyedTree copyFrom: 1 to: 4)
+		assert: (error copyFrom: 1 to: 4)
 		equals: (Array with: 0 with: Float infinity with: -100.0 with: Float infinity negated).
-	self assert: (keyedTree at: 5) isNaN
+	self assert: (error at: 5) isNaN.
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
+++ b/src/Math-Tests-Accuracy/PMDataTreeTest.class.st
@@ -40,9 +40,6 @@ PMDataTreeTest >> testDataTree [
 	| s |
 	a run.
 	self
-		assert: (a dataTree atPath: #('names' 'Aaa' 'data'))
-		equals: #(#(1 2) #(3 2.8888)).
-	self
 		assert: (a dataTree atPath: #('names' 'Bbb' #(3) 'data'))
 		equals: #(#(2) #(3)).
 	s := a dataTree atPath: #('names' 'Ccc' #(3)).
@@ -52,6 +49,17 @@ PMDataTreeTest >> testDataTree [
 		assert: (s copyFrom: 1 to: 4)
 		equals: (Array with: 0 with: Float infinity with: -100.0 with: Float infinity negated).
 	self assert: (s at: 5) isNaN
+]
+
+{ #category : #tests }
+PMDataTreeTest >> testThatDataForAaaIsTheCorrespondingParameter [
+	| parameterForAaa |
+	a run.
+	
+	parameterForAaa := #(#(1 2) #(3 2.8888)).
+	self
+		assert: (a dataTree atPath: #('names' 'Aaa' 'data'))
+		equals: parameterForAaa.
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Issue #154 is proving a little difficult to fix. Therefore I have begun a targeted refactor of the production and test code to help a future developer understand what the Accuracy package does easily.
This PR breaks up the `testDataTree` code into smaller (hopefully easier to understand) blocks of code.
What is interesting here is that the `run` message is the generator of the dataTree object. It feels that that is what we are really testing.

The reason I chose to work on the `testDataTree` message first is that from my earlier spike, I discovered that part of that method fails when I try to get the Accuracy package covered by coveralls.io in the [usual way](https://github.com/PolyMathOrg/PolyMath/pull/140).