### PR TITLE
Issue 154 Refactoring - Make The Test More Specific By Breaking It Up

### DIFF
--- a/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
@@ -84,14 +84,18 @@ PMAccuracyTest >> testDecimalPlaces [
 
 { #category : #tests }
 PMAccuracyTest >> testExtractFromResultsWhichOnlyOne [
+	| argument |
 	self
 		assert: (a extractFromResults: #('bla' 'blah') which: 2 onlyOne: false)
 		equals: 'blah'.
-	self assert: a testGetterAaa second equals: #(true).
+	argument := a testGetterAaa second.
+	self assert: argument equals: #(true).
+	
 	self
 		assert: (a extractFromResults: #('bla' 'blah') which: 1 onlyOne: true)
 		equals: #('bla' 'blah').
-	self assert: a testGetterAaa second equals: #(#(false) #(true))
+	argument := a testGetterAaa second.
+	self assert: argument equals: #(#(false) #(true))
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
@@ -83,19 +83,23 @@ PMAccuracyTest >> testDecimalPlaces [
 ]
 
 { #category : #tests }
-PMAccuracyTest >> testExtractFromResultsWhichOnlyOne [
+PMAccuracyTest >> testExtractFromResultsReturnsAllElementsWhenOnlyOneIsTrue [
+	| argument |
+	self
+		assert: (a extractFromResults: #('bla' 'blah') which: 1 onlyOne: true)
+		equals: #('bla' 'blah').
+	argument := a testGetterAaa second.
+	self assert: argument equals: #(#(false) #(true))
+]
+
+{ #category : #tests }
+PMAccuracyTest >> testExtractFromResultsReturnsTheCorrectIndexedElementWhenOnlyOneIsFalse [
 	| argument |
 	self
 		assert: (a extractFromResults: #('bla' 'blah') which: 2 onlyOne: false)
 		equals: 'blah'.
 	argument := a testGetterAaa second.
 	self assert: argument equals: #(true).
-	
-	self
-		assert: (a extractFromResults: #('bla' 'blah') which: 1 onlyOne: true)
-		equals: #('bla' 'blah').
-	argument := a testGetterAaa second.
-	self assert: argument equals: #(#(false) #(true))
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTest.class.st
@@ -84,22 +84,28 @@ PMAccuracyTest >> testDecimalPlaces [
 
 { #category : #tests }
 PMAccuracyTest >> testExtractFromResultsReturnsAllElementsWhenOnlyOneIsTrue [
-	| argument |
-	self
-		assert: (a extractFromResults: #('bla' 'blah') which: 1 onlyOne: true)
-		equals: #('bla' 'blah').
+	| argument results |
+	results := a
+		extractFromResults: #('bla' 'blah')
+		which: 1
+		onlyOne: true.
+	
+	self assert: results equals: #('bla' 'blah').
 	argument := a testGetterAaa second.
 	self assert: argument equals: #(#(false) #(true))
 ]
 
 { #category : #tests }
 PMAccuracyTest >> testExtractFromResultsReturnsTheCorrectIndexedElementWhenOnlyOneIsFalse [
-	| argument |
-	self
-		assert: (a extractFromResults: #('bla' 'blah') which: 2 onlyOne: false)
-		equals: 'blah'.
+	| argument results |
+	results := a
+		extractFromResults: #('bla' 'blah')
+		which: 2
+		onlyOne: false.
+
+	self assert: results equals: 'blah'.
 	argument := a testGetterAaa second.
-	self assert: argument equals: #(true).
+	self assert: argument equals: #(true)
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
@@ -13,6 +13,14 @@ Class {
 	#category : #'Math-Tests-Accuracy'
 }
 
+{ #category : #private }
+PMAccuracyTestExample >> argumentWith: key [ 
+	| r |
+	r := self argumentAt: key.
+	numberOfResults ifNotNil: [ :rn | r := r at: rn ].
+	^ r
+]
+
 { #category : #tests }
 PMAccuracyTestExample >> checkAaa [
 	self argument first
@@ -146,7 +154,7 @@ PMAccuracyTestExample >> tearDown [
 PMAccuracyTestExample >> testGetterAaa [
 ^Array
 	with: self parameter
-	with: self argument
+	with: (self argumentWith: 'Aaa')
 	with: (self resultsAt: 'Aaa')
 	with: (self numberOfDifferentParametersAt: 'Aaa')
 	with: (self numberOfDifferentResultsAt: 'Aaa')
@@ -156,7 +164,7 @@ PMAccuracyTestExample >> testGetterAaa [
 PMAccuracyTestExample >> testGetterBbb [
 ^Array
 	with: self parameter
-	with: self argument
+	with: (self argumentWith: 'Bbb')
 	with: (self resultsAt: 'Bbb')
 	with: (self numberOfDifferentParametersAt: 'Bbb')
 	with: (self numberOfDifferentResultsAt: 'Bbb')

--- a/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
@@ -15,10 +15,10 @@ Class {
 
 { #category : #private }
 PMAccuracyTestExample >> argumentWith: key [ 
-	| r |
-	r := self argumentAt: key.
-	numberOfResults ifNotNil: [ :rn | r := r at: rn ].
-	^ r
+	| theArgument |
+	theArgument := self argumentAt: key.
+	numberOfResults ifNotNil: [ :rn | theArgument := theArgument at: rn ].
+	^ theArgument
 ]
 
 { #category : #tests }


### PR DESCRIPTION
## Issue: #154
 
In the `issue-154` branch, having configured coverall.io to track the `Accuracy-Core` package, I discovered that `#testExtractFromResultsWhichOnlyOne` was [failing on travisCI](https://travis-ci.org/github/PolyMathOrg/PolyMath/jobs/647741214?utm_medium=notification&utm_source=github_status), specifically, the first of the two assertions.

The name of the test is not very helpful so in this refactoring PR I have broken it up and made the names (hopefully) a little clearer. In addition I've extracted code to role revealing local variables. We can get to the root cause of why it is failing on travisCI in later dev work.

In addition, I introduced a new method, `argumentWith:`, so that we can be explicit about the key we want get the argument for, and replaced calls to `argument` with it. This will make the code easier to understand and debug.