### PR TITLE
Issue 154 test coverage

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -9,6 +9,7 @@ SmalltalkCISpec {
   #testing : {
     #coverage : {
       #packages : [
+        'Math-Accuracy-Core',
         'Math-Accuracy-ODE',
 	'Math-ArbitraryPrecisionFloat',
 	'Math-AutomaticDifferenciation',

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -9,10 +9,7 @@ SmalltalkCISpec {
   #testing : {
     #coverage : {
       #packages : [
-        'Math-Accuracy-Core',
-        'Math-Accuracy-ODE',
-	'Math-ArbitraryPrecisionFloat',
-	'Math-AutomaticDifferenciation',
+        'Math-A*',
 	'Math-B*',
 	'Math-C*',
 	'Math-D*',

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Metacello new
 ```
 
 
-We have **815** green tests ! At the moment, all the development happens in the master branch (we are using trunk-based development).
+We have **816** green tests ! At the moment, all the development happens in the master branch (we are using trunk-based development).
 
 PolyMath is a Pharo project, similar to existing scientific libraries like NumPy, SciPy for Python or SciRuby for Ruby. PolyMath already provides the following basic functionalities:
 - complex and quaternions extensions,

--- a/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
+++ b/src/Math-Tests-Accuracy/PMAccuracyTestExample.class.st
@@ -23,19 +23,19 @@ PMAccuracyTestExample >> argumentWith: key [
 
 { #category : #tests }
 PMAccuracyTestExample >> checkAaa [
-	self argument first
+	(self argumentWith: 'Aaa') first
 		ifTrue: [ ^ #(1 1) ].
 	^ Array with: (4 + (0.4 * Random new next)) with: 2
 ]
 
 { #category : #tests }
 PMAccuracyTestExample >> checkBbb [
-	^ self argument first size + self parameter first
+	^ (self argumentWith: 'Bbb') first size + self parameter first
 ]
 
 { #category : #tests }
 PMAccuracyTestExample >> checkCcc [
-	^ self argument first + (0.01 * self parameter first)
+	^ (self argumentWith: 'Ccc') first + (0.01 * self parameter first)
 ]
 
 { #category : #tests }


### PR DESCRIPTION
**Issue:** #154 

This finally puts test coverage on the `Math-Accuracy-Core` package via coveralls.io. Along the way we needed to replace calls to the `argument` message with `argumentWith:`.