### PR TITLE
Use XMLWriter 2.9.x to avoid conflicts with other packages : https://…

### DIFF
--- a/src/BaselineOfPolyMath/BaselineOfPolyMath.class.st
+++ b/src/BaselineOfPolyMath/BaselineOfPolyMath.class.st
@@ -28,7 +28,7 @@ BaselineOfPolyMath >> baseline: spec [
 					with: [ spec repository: 'github://smarr/SMark:v1.0.4' ];
 				baseline: 'XMLWriter'
 					with: [ spec
-						repository: 'github://pharo-contributions/XML-XMLWriter:2.9.0/src' ].
+						repository: 'github://pharo-contributions/XML-XMLWriter:2.9.x/src' ].
 			spec
 				package: 'ExtendedNumberParser';
 				package: 'Math-Accuracy-Core';


### PR DESCRIPTION
…github.com/PolyMathOrg/PolyMath/issues/169

Tested also loading XMLParser (which also installs XMLWriter 2.9.x) without conflicts

```smalltalk
Metacello new
	baseline: 'XMLParser';
	repository: 'github://pharo-contributions/XML-XMLParser/src';
	load.
```
