### PR TITLE
testHouseholder added

### DIFF
--- a/src/Math-Tests-Core/PMVectorTest.class.st
+++ b/src/Math-Tests-Core/PMVectorTest.class.st
@@ -75,13 +75,11 @@ PMVectorTest >> testHouseholder [
 	u := #(-1 0 1) asPMVector. "`x <= 0` when x = -1"
 	w := u householder.
 	self
-		assert: w class equals: Array;
 		assert: (w at: 1) equals: 1.7071067811865475;
 		assert: (w at: 2) asArray equals: #(1.0 -0.0 -0.4142135623730951).
 	u := #(1.00001 2.00007) asPMVector. "`x <= 0` when x = 1.00001"
 	w := u householder.
 	self
-		assert: w class equals: Array;
 		assert: (w at: 1) equals: 0.5527953485259909;
 		assert: (w at: 2) asArray equals: #(1.0 -1.6180158992689828).
 ]

--- a/src/Math-Tests-Core/PMVectorTest.class.st
+++ b/src/Math-Tests-Core/PMVectorTest.class.st
@@ -70,6 +70,23 @@ PMVectorTest >> testGreaterThan [
 ]
 
 { #category : #tests }
+PMVectorTest >> testHouseholder [
+	| u w |
+	u := #(-1 0 1) asPMVector. "`x <= 0` when x = -1"
+	w := u householder.
+	self
+		assert: w class equals: Array;
+		assert: (w at: 1) equals: 1.7071067811865475;
+		assert: (w at: 2) asArray equals: #(1.0 -0.0 -0.4142135623730951).
+	u := #(1.00001 2.00007) asPMVector. "`x <= 0` when x = 1.00001"
+	w := u householder.
+	self
+		assert: w class equals: Array;
+		assert: (w at: 1) equals: 0.5527953485259909;
+		assert: (w at: 2) asArray equals: #(1.0 -1.6180158992689828).
+]
+
+{ #category : #tests }
 PMVectorTest >> testLessThan [
 	| vec vecCopy |
 	vec := #(1 2 3) asPMVector.
@@ -79,7 +96,7 @@ PMVectorTest >> testLessThan [
 	self assert: vec equals: vecCopy asPMVector.
 ]
 
-{ #category : #tests } 
+{ #category : #tests }
 PMVectorTest >> testMatrixConversionWithBothDims [
 	| vect result expected |
 	vect := #(1 0.5 0.2 3 1 -1 7 3 2 12 13 3) asPMVector .


### PR DESCRIPTION
I submit this pull request to suggest a test method `PMVectorTest >> testHouseholder`.

We noticed that the method #householder is never executed by any of the tests in PMVectorTest. Therefore we created a test method which uses two vectors to exercise both branches in line 203 `(x <=0) ifTrue: [x -u] ifFalse:  [0 - s / (x + u)]`. In the former vector `x = -1` forces the ifTrue branch in the latter  vector `x = 1.00001` forces the ifFalse branch. 

Note that these suggestions are adapted from a test amplification tool called SmallAmp (https://github.com/mabdi/small-amp). SmallAmp executes existing tests, sees which parts of the class under test are not covered and then suggests improvements on the test methods.

I hope you will accept this pull request. It would illustrate that SmallAmp makes relevant suggestions.

Mehrdad Abdi.
