### PR TITLE
Fix bug in quantile: where the input probability is given as a float.

### DIFF
--- a/src/Math-Quantile/SortedCollection.extension.st
+++ b/src/Math-Quantile/SortedCollection.extension.st
@@ -88,7 +88,7 @@ SortedCollection >> quantile: aProbability withProbs: anArray [
 		ifTrue: [ 1 ]
 		ifFalse: [ p min: self size ].
 	^ p truncated = p
-		ifTrue: [ self at: p ]
+		ifTrue: [ self at: p asInteger ] "we have to convert io integer here for cases where aProbability was a Float"
 		ifFalse: [ (f := self at: p floor)
 				+ (((self at: p ceiling) - f) * (p fractionPart * d + c)) ]
 ]

--- a/src/Math-Tests-Quantile/PMQuantileTest.class.st
+++ b/src/Math-Tests-Quantile/PMQuantileTest.class.st
@@ -59,6 +59,15 @@ PMQuantileTest >> testExtremeCase [
 ]
 
 { #category : #tests }
+PMQuantileTest >> testFloatProbability [
+	"tests that input quantile probabilities can be a float"	
+			
+	self assert: (c quantile: 0.25) equals: 2.
+	
+	self assert: (c quantile: 0.27) equals: 2.08
+]
+
+{ #category : #tests }
 PMQuantileTest >> testQuantileA [
 	self
 		assert: (self resultCollect: a method: #modeBased)


### PR DESCRIPTION
In Pharo 9, in cases like where the input probability is a Float and not a Fraction like
```
#(1 2 3 4 5) asSortedCollection quantile: 0.25
```
an error gets thrown as `SortedCollection` requires an Integer for an index. With the previous code
the value of the temporary value, `p`, could end up being a Float like `2.0` that would equal the integer
( i.e. `p truncate = p` ) but using `2.0` as an index no longer works.