### PR TITLE
add atRow: method for PMMatrix

### DIFF
--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -270,9 +270,9 @@ PMMatrix >> atAllPut: element [
 ]
 
 { #category : #'cell accessing' }
-PMMatrix >> atColumn: acolumnNumber [
+PMMatrix >> atColumn: aColumnNumber [
 
-	^ self columnAt: acolumnNumber
+	^ self columnAt: aColumnNumber
 ]
 
 { #category : #'cell accessing' }

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -312,6 +312,12 @@ PMMatrix >> atColumn: aColumnNumber put: aCollection startingAt: rowNumber [
 ]
 
 { #category : #'cell accessing' }
+PMMatrix >> atRow: anInteger [
+
+	^ self rowAt: anInteger
+]
+
+{ #category : #'cell accessing' }
 PMMatrix >> atRow: rowIndex put: aCollection [
 
 	aCollection withIndexDo: [: value : columnIndex |

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -270,9 +270,9 @@ PMMatrix >> atAllPut: element [
 ]
 
 { #category : #'cell accessing' }
-PMMatrix >> atColumn: anInteger [
+PMMatrix >> atColumn: acolumnNumber [
 
-	^ self columnAt: anInteger
+	^ self columnAt: acolumnNumber
 ]
 
 { #category : #'cell accessing' }
@@ -312,9 +312,9 @@ PMMatrix >> atColumn: aColumnNumber put: aCollection startingAt: rowNumber [
 ]
 
 { #category : #'cell accessing' }
-PMMatrix >> atRow: anInteger [
-
-	^ self rowAt: anInteger
+PMMatrix >> atRow: aRowNumber [
+	"answers the aRowNumber-th row in the receiver"
+	^ self rowAt: aRowNumber
 ]
 
 { #category : #'cell accessing' }

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -48,6 +48,16 @@ PMMatrixTest >> testAtColumnPutRepeat [
 	self assert: a equals: (PMMatrix rows: #(#(1 nil nil) #(1 nil nil) #(nil nil nil))).
 ]
 
+{ #category : #tests }
+PMMatrixTest >> testAtRow [
+
+	| a |
+	a := PMMatrix rows: #(#(1 2 3) #(2 3 4)).
+	
+	self assert: (a atRow: 2) equals: (#(2 3 4) asPMVector).
+	self assert: (a atRow: 1) equals: (#(1 2 3) asPMVector).	
+]
+
 { #category : #'linear algebra' }
 PMMatrixTest >> testAtRowPutAtColumnPut [
 	| a |


### PR DESCRIPTION
The `PMMatrix` class did not have the method `atRow:` initialised even though the method `atColumn:` was initialised.

The method, `atRow:` is introduced through this PR.