### PR TITLE
add identity matrix instance creation for PMMatrix

### DIFF
--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -68,6 +68,11 @@ a tr.
 ]
 
 { #category : #'instance creation' }
+PMMatrix class >> identity: anInteger [ 
+  ^ PMSymmetricMatrix identity: anInteger 
+]
+
+{ #category : #'instance creation' }
 PMMatrix class >> join: anArrayOfMatrices [
 		"Inverse of the split operation."
 	| rows n row rowSize n1 n2 |

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -68,8 +68,8 @@ a tr.
 ]
 
 { #category : #'instance creation' }
-PMMatrix class >> identity: anInteger [ 
-  ^ PMSymmetricMatrix identity: anInteger 
+PMMatrix class >> identity: dimension [
+  ^ PMSymmetricMatrix identity: dimension
 ]
 
 { #category : #'instance creation' }

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -199,16 +199,16 @@ PMMatrixTest >> testFlattenRows [
 
 { #category : #tests }
 PMMatrixTest >> testIdentityMatrix [
-	|a a2|
+	|expectedIdentityMatrix identityMatrix|
 
-	a := PMMatrix zerosRows: 3 cols: 3.
+	expectedIdentityMatrix := PMMatrix zerosRows: 3 cols: 3.
 
-	a at: 1 at: 1 put: 1.
-	a at: 2 at: 2 put: 1.
-	a at: 3 at: 3 put: 1.
+	expectedIdentityMatrix at: 1 at: 1 put: 1.
+	expectedIdentityMatrix at: 2 at: 2 put: 1.
+	expectedIdentityMatrix at: 3 at: 3 put: 1.
 
-	a2 := PMMatrix identity: 3.
-	self assert: a2 equals: a.
+	identityMatrix := PMMatrix identity: 3.
+	self assert: identityMatrix equals: identityMatrix.
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -198,6 +198,20 @@ PMMatrixTest >> testFlattenRows [
 ]
 
 { #category : #tests }
+PMMatrixTest >> testIdentityMatrix [
+	|a a2|
+
+	a := PMMatrix zerosRows: 3 cols: 3.
+
+	a at: 1 at: 1 put: 1.
+	a at: 2 at: 2 put: 1.
+	a at: 3 at: 3 put: 1.
+
+	a2 := PMMatrix identity: 3.
+	self assert: a2 equals: a.
+]
+
+{ #category : #tests }
 PMMatrixTest >> testIsRealOnComplexMatrix [
 	| matrix |
 	

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -208,7 +208,7 @@ PMMatrixTest >> testIdentityMatrix [
 	expectedIdentityMatrix at: 3 at: 3 put: 1.
 
 	identityMatrix := PMMatrix identity: 3.
-	self assert: identityMatrix equals: identityMatrix.
+	self assert: identityMatrix equals: expectedIdentityMatrix.
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMSymmetricMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMSymmetricMatrixTest.class.st
@@ -40,12 +40,12 @@ PMSymmetricMatrixTest >> testEqual [
 
 { #category : #tests }
 PMSymmetricMatrixTest >> testIdentityMatrix [
-	|a a1|
+	|expectedIdentityMatrix identityMatrix|
 
-	a := PMSymmetricMatrix identity: 3.
-	a1 := PMSymmetricMatrix rows: #(#(1 0 0) #(0 1 0) #(0 0 1)).
+	identityMatrix := PMSymmetricMatrix identity: 3.
+	expectedIdentityMatrix := PMSymmetricMatrix rows: #(#(1 0 0) #(0 1 0) #(0 0 1)).
 
-	self assert: a equals: a1.
+	self assert: identityMatrix equals: expectedIdentityMatrix.
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMSymmetricMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMSymmetricMatrixTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PMSymmetricMatrixTest,
 	#superclass : #TestCase,
-	#category : 'Math-Tests-Matrix'
+	#category : #'Math-Tests-Matrix'
 }
 
 { #category : #tests }
@@ -36,6 +36,16 @@ PMSymmetricMatrixTest >> testEqual [
 	self assert: b ~= a.
 	a := 's'.
 	self assert: b ~= a
+]
+
+{ #category : #tests }
+PMSymmetricMatrixTest >> testIdentityMatrix [
+	|a a1|
+
+	a := PMSymmetricMatrix identity: 3.
+	a1 := PMSymmetricMatrix rows: #(#(1 0 0) #(0 1 0) #(0 0 1)).
+
+	self assert: a equals: a1.
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Changes introduced from this PR
- Identity matrix can now be initialized using PMMatrix class
- Added tests for Identity matrix initialization using PMMatrix class
- Added tests for Identity matrix initialization using PMSymmetricMatrix class.