### PR TITLE
handle negative values for shapes in PMMatrix

### DIFF
--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -102,10 +102,10 @@ PMMatrix class >> lupCRLCriticalDimension [
 ]
 
 { #category : #'instance creation' }
-PMMatrix class >> new: anInteger [
+PMMatrix class >> new: dimension [
 	"Create an empty square matrix of dimension anInteger."
 
-	^ self new initializeSquare: anInteger
+	^ self new initializeSquare: dimension
 ]
 
 { #category : #'instance creation' }
@@ -520,9 +520,9 @@ PMMatrix >> initializeRows: rowsInteger columns: columnsInteger [
 ]
 
 { #category : #initialization }
-PMMatrix >> initializeSquare: anInteger [
+PMMatrix >> initializeSquare: dimension [
 	"Build empty components for a square matrix. No check is made: components are assumed to be orgainized in rows."
-	^ self initializeRows: anInteger  columns: anInteger 
+	^ self initializeRows: dimension  columns: dimension 
 ]
 
 { #category : #operation }

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -521,8 +521,8 @@ PMMatrix >> initializeRows: anArrayOrVector [
 { #category : #initialization }
 PMMatrix >> initializeRows: rowsInteger columns: columnsInteger [
 	"Build empty components for a matrix."
-	[ rowsInteger  isInteger and: [ rowsInteger   >= 0 ] ] assert.
-	[ columnsInteger  isInteger and: [ columnsInteger  >= 0 ] ] assert.
+	self assert: [ rowsInteger  isInteger and: [ rowsInteger   >= 0 ] ] description: 'Row size of a matrix must be a positive integer'.
+	self assert: [ columnsInteger  isInteger and: [ columnsInteger  >= 0 ] ]  description: 'Column size of a matrix must be a positive integer'.
 	rows := (1 to: rowsInteger) asPMVector collect: [ :each | PMVector new: columnsInteger ].
 ]
 

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -105,7 +105,7 @@ PMMatrix class >> lupCRLCriticalDimension [
 PMMatrix class >> new: anInteger [
 	"Create an empty square matrix of dimension anInteger."
 
-	^ self new initialize: anInteger
+	^ self new initializeSquare: anInteger
 ]
 
 { #category : #'instance creation' }
@@ -506,13 +506,6 @@ PMMatrix >> hash [
 ]
 
 { #category : #initialization }
-PMMatrix >> initialize: anInteger [
-	"Build empty components for a square matrix. No check is made: components are assumed to be orgainized in rows."
-	[ anInteger isInteger and: [ anInteger  >= 0 ] ] assert.
-	rows := (1 to: anInteger) asPMVector collect: [ :each | PMVector new: anInteger].
-]
-
-{ #category : #initialization }
 PMMatrix >> initializeRows: anArrayOrVector [
 	"Defines the components of the recevier. No check is made: components are assumed to be orgainized in rows."
 	rows := anArrayOrVector asPMVector collect: [ :each | each asPMVector].
@@ -524,6 +517,12 @@ PMMatrix >> initializeRows: rowsInteger columns: columnsInteger [
 	self assert: [ rowsInteger  isInteger and: [ rowsInteger   >= 0 ] ] description: 'Row size of a matrix must be a positive integer'.
 	self assert: [ columnsInteger  isInteger and: [ columnsInteger  >= 0 ] ]  description: 'Column size of a matrix must be a positive integer'.
 	rows := (1 to: rowsInteger) asPMVector collect: [ :each | PMVector new: columnsInteger ].
+]
+
+{ #category : #initialization }
+PMMatrix >> initializeSquare: anInteger [
+	"Build empty components for a square matrix. No check is made: components are assumed to be orgainized in rows."
+	^ self initializeRows: anInteger  columns: anInteger 
 ]
 
 { #category : #operation }

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -103,7 +103,7 @@ PMMatrix class >> lupCRLCriticalDimension [
 
 { #category : #'instance creation' }
 PMMatrix class >> new: dimension [
-	"Create an empty square matrix of dimension anInteger."
+	"Create an empty square matrix of size dimension x dimension."
 
 	^ self new initializeSquare: dimension
 ]

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -514,8 +514,8 @@ PMMatrix >> initializeRows: anArrayOrVector [
 { #category : #initialization }
 PMMatrix >> initializeRows: rowsInteger columns: columnsInteger [
 	"Build empty components for a matrix."
-	self assert: [ rowsInteger  isInteger and: [ rowsInteger   >= 0 ] ] description: 'Row size of a matrix must be a positive integer'.
-	self assert: [ columnsInteger  isInteger and: [ columnsInteger  >= 0 ] ]  description: 'Column size of a matrix must be a positive integer'.
+	self assert: [ rowsInteger  isInteger and: [ rowsInteger   > 0 ] ] description: 'Row size of a matrix must be a positive integer'.
+	self assert: [ columnsInteger  isInteger and: [ columnsInteger  > 0 ] ]  description: 'Column size of a matrix must be a positive integer'.
 	rows := (1 to: rowsInteger) asPMVector collect: [ :each | PMVector new: columnsInteger ].
 ]
 

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -508,6 +508,7 @@ PMMatrix >> hash [
 { #category : #initialization }
 PMMatrix >> initialize: anInteger [
 	"Build empty components for a square matrix. No check is made: components are assumed to be orgainized in rows."
+	[ anInteger isInteger and: [ anInteger  >= 0 ] ] assert.
 	rows := (1 to: anInteger) asPMVector collect: [ :each | PMVector new: anInteger].
 ]
 
@@ -520,7 +521,8 @@ PMMatrix >> initializeRows: anArrayOrVector [
 { #category : #initialization }
 PMMatrix >> initializeRows: rowsInteger columns: columnsInteger [
 	"Build empty components for a matrix."
-		
+	[ rowsInteger  isInteger and: [ rowsInteger   >= 0 ] ] assert.
+	[ columnsInteger  isInteger and: [ columnsInteger  >= 0 ] ] assert.
 	rows := (1 to: rowsInteger) asPMVector collect: [ :each | PMVector new: columnsInteger ].
 ]
 

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -480,7 +480,7 @@ PMMatrixTest >> testMatrixInitializationWithNegativeDimensions [
 { #category : #'linear algebra' }
 PMMatrixTest >> testMatrixInitialize [
 	| a |
-	a := PMMatrix new initialize: 2.
+	a := PMMatrix new initializeSquare: 2.
 	self assert: a numberOfRows equals: 2.
 	self assert: a numberOfColumns equals: 2.
 

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -473,8 +473,9 @@ PMMatrixTest >> testMatrixHash [
 { #category : #'linear algebra' }
 PMMatrixTest >> testMatrixInitializationWithNegativeDimensions [
 	
+	" matrices with negative dimension and zero dimension should not be allowed."
 	self should: [ PMMatrix new: -2 ] raise: AssertionFailure .
-	self should: [ PMMatrix rows: -3 columns: 4 ] raise: AssertionFailure.
+	self should: [ PMMatrix rows: 0 columns: 4 ] raise: AssertionFailure.
 ]
 
 { #category : #'linear algebra' }

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -471,14 +471,19 @@ PMMatrixTest >> testMatrixHash [
 ]
 
 { #category : #'linear algebra' }
+PMMatrixTest >> testMatrixInitializationWithNegativeDimensions [
+	
+	self should: [ PMMatrix new: -2 ] raise: AssertionFailure .
+	self should: [ PMMatrix rows: -3 columns: 4 ] raise: AssertionFailure.
+]
+
+{ #category : #'linear algebra' }
 PMMatrixTest >> testMatrixInitialize [
 	| a |
 	a := PMMatrix new initialize: 2.
 	self assert: a numberOfRows equals: 2.
 	self assert: a numberOfColumns equals: 2.
-	
-	self should: [ PMMatrix new: -2 ] raise: AssertionFailure .
-	self should: [ PMMatrix rows: -3 columns: 4 ] raise: AssertionFailure.
+
 ]
 
 { #category : #'linear algebra' }

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -479,11 +479,11 @@ PMMatrixTest >> testMatrixInitializationWithNegativeDimensions [
 ]
 
 { #category : #'linear algebra' }
-PMMatrixTest >> testMatrixInitialize [
-	| a |
-	a := PMMatrix new initializeSquare: 2.
-	self assert: a numberOfRows equals: 2.
-	self assert: a numberOfColumns equals: 2.
+PMMatrixTest >> testMatrixInitializeSquare [
+	| aPMMatrix |
+	aPMMatrix := PMMatrix new initializeSquare: 2.
+	self assert: aPMMatrix numberOfRows equals: 2.
+	self assert: aPMMatrix numberOfColumns equals: 2.
 
 ]
 
@@ -536,6 +536,15 @@ PMMatrixTest >> testMatrixMultiply [
 	self assert: ((c rowAt: 2) at: 1) equals: 18.
 	self assert: ((c rowAt: 2) at: 2) equals: 14.
 	self assert: ((c rowAt: 2) at: 3) equals: 4
+]
+
+{ #category : #'linear algebra' }
+PMMatrixTest >> testMatrixNew [
+	| aPMMatrix |
+	aPMMatrix  := PMMatrix new: 3.
+	self assert: aPMMatrix numberOfRows equals: 3.
+	self assert: aPMMatrix numberOfColumns equals: 3.
+
 ]
 
 { #category : #'linear algebra' }

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -475,7 +475,10 @@ PMMatrixTest >> testMatrixInitialize [
 	| a |
 	a := PMMatrix new initialize: 2.
 	self assert: a numberOfRows equals: 2.
-	self assert: a numberOfColumns equals: 2
+	self assert: a numberOfColumns equals: 2.
+	
+	self should: [ PMMatrix new: -2 ] raise: AssertionFailure .
+	self should: [ PMMatrix rows: -3 columns: 4 ] raise: AssertionFailure.
 ]
 
 { #category : #'linear algebra' }

--- a/src/Math-Tests-Numerical/PMNumericalMethodsTestCase.class.st
+++ b/src/Math-Tests-Numerical/PMNumericalMethodsTestCase.class.st
@@ -639,7 +639,7 @@ PMNumericalMethodsTestCase >> testMatrixHash [
 { #category : #'linear algebra' }
 PMNumericalMethodsTestCase >> testMatrixInitialize [
 	| a |
-	a := PMMatrix new initialize: 2.
+	a := PMMatrix new initializeSquare:  2.
 	self assert: a numberOfRows equals: 2.
 	self assert: a numberOfColumns equals: 2
 ]

--- a/src/Math-Tests-Numerical/PMNumericalMethodsTestCase.class.st
+++ b/src/Math-Tests-Numerical/PMNumericalMethodsTestCase.class.st
@@ -637,11 +637,11 @@ PMNumericalMethodsTestCase >> testMatrixHash [
 ]
 
 { #category : #'linear algebra' }
-PMNumericalMethodsTestCase >> testMatrixInitialize [
-	| a |
-	a := PMMatrix new initializeSquare:  2.
-	self assert: a numberOfRows equals: 2.
-	self assert: a numberOfColumns equals: 2
+PMNumericalMethodsTestCase >> testMatrixInitializeSquare [
+	| aPMMatrix |
+	aPMMatrix := PMMatrix new initializeSquare:  2.
+	self assert: aPMMatrix numberOfRows equals: 2.
+	self assert: aPMMatrix numberOfColumns equals: 2
 ]
 
 { #category : #'linear algebra' }


### PR DESCRIPTION
This PR solves the issue - #205 partially.
Changes introduced with this PR :
- When negative values are given as input to the shapes of a PMMatrix, an AssertionFailure error is returned.