### PR TITLE
check for invalid shapes in strassen multiplication

### DIFF
--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -950,8 +950,13 @@ PMMatrix >> squared [
 PMMatrix >> strassenProductWithMatrix: aMatrix [
 	"Private"
 	| matrixSplit selfSplit p1 p2 p3 p4 p5 p6 p7 |
+
 	( self numberOfRows > 2 and: [ self numberOfColumns > 2])
 		ifFalse:[ ^self class rows: ( aMatrix rowsCollect: [ :row | self columnsCollect: [ :col | row * col]])].
+	
+	self assert: [ self numberOfRows isPowerOfTwo and: self numberOfColumns isPowerOfTwo  ] description: 'Matrix size should be a power of two'.
+	self assert: [ aMatrix numberOfRows isPowerOfTwo and: aMatrix numberOfColumns isPowerOfTwo  ] description: 'Matrix size should be a power of two'.
+		
 	selfSplit := self split.
 	matrixSplit := aMatrix split.
 	p1 := ( ( selfSplit at: 2) - ( selfSplit at: 4)) strassenProductWithMatrix: ( matrixSplit at: 1).

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -742,7 +742,7 @@ PMMatrixTest >> testStrassenProductWithMatrix [
 		
 	| aPMMatrix expected strassenProduct |
 	
-   aPMMatrix := PMMatrix rows: #( (1 2 3 4) (1 0 1 2) (2 3 1 4) (4 3 2 2)).
+	aPMMatrix := PMMatrix rows: #( (1 2 3 4) (1 0 1 2) (2 3 1 4) (4 3 2 2)).
 	expected  := PMMatrix rows: #( (30 12 27 24) (12 6 11 10) (27 11 30 27) (24 10 27 33)).
 	strassenProduct := aPMMatrix transpose strassenProductWithMatrix: aPMMatrix.
 	self assert: strassenProduct equals: expected.
@@ -754,7 +754,7 @@ PMMatrixTest >> testStrassenProductWithMatrixWithInvalidShapes [
 	| aPMMatrix |
 	
 	"all the dimension of the matrices should be a power of 2 for strassen multiplication"
-   aPMMatrix := PMMatrix rows: #( (1 2 3) (1 0 1) (2 3 1) (2 0 1)).
+	aPMMatrix := PMMatrix rows: #( (1 2 3) (1 0 1) (2 3 1) (2 0 1)).
 	
 	self should: [ aPMMatrix strassenProductWithMatrix: aPMMatrix transpose ] raise: AssertionFailure.
 

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -745,7 +745,7 @@ PMMatrixTest >> testStrassenProductWithMatrix [
    aPMMatrix := PMMatrix rows: #( (1 2 3 4) (1 0 1 2) (2 3 1 4) (4 3 2 2)).
 	expected  := PMMatrix rows: #( (30 12 27 24) (12 6 11 10) (27 11 30 27) (24 10 27 33)).
 	strassenProduct := aPMMatrix transpose strassenProductWithMatrix: aPMMatrix.
-	self assert: expected  equals: strassenProduct.
+	self assert: strassenProduct equals: expected.
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -738,6 +738,29 @@ PMMatrixTest >> testSkalarMultiplication [
 ]
 
 { #category : #tests }
+PMMatrixTest >> testStrassenProductWithMatrix [
+		
+	| aPMMatrix expected strassenProduct |
+	
+   aPMMatrix := PMMatrix rows: #( (1 2 3 4) (1 0 1 2) (2 3 1 4) (4 3 2 2)).
+	expected  := PMMatrix rows: #( (30 12 27 24) (12 6 11 10) (27 11 30 27) (24 10 27 33)).
+	strassenProduct := aPMMatrix transpose strassenProductWithMatrix: aPMMatrix.
+	self assert: expected  equals: strassenProduct.
+]
+
+{ #category : #tests }
+PMMatrixTest >> testStrassenProductWithMatrixWithInvalidShapes [
+		
+	| aPMMatrix |
+	
+	"all the dimension of the matrices should be a power of 2 for strassen multiplication"
+   aPMMatrix := PMMatrix rows: #( (1 2 3) (1 0 1) (2 3 1) (2 0 1)).
+	
+	self should: [ aPMMatrix strassenProductWithMatrix: aPMMatrix transpose ] raise: AssertionFailure.
+
+]
+
+{ #category : #tests }
 PMMatrixTest >> testSymmetric [
 |a m|
 a:=#(1 2 3)asPMVector.


### PR DESCRIPTION
Strassen multiplication between two matrices is only possible when the dimensions of both the matrices are a power of 2.
Currently, we get an error when we try to do `strassenProductWithMatrix:` with a matrix of dimension that is not a power of 2.

Changes introduced with this PR:
- An assertion condition is added to the `strassenProductWithMatrix:` method that checks that the shapes of the matrices are a power of 2.
- Unit test to check if the assertion failure is raised when `stassenProductWithMatrix` is called on invalid shapes.
- Unit test that checks if the output of Strassen multiplication on two valid matrices is correct

A better solution for this [problem](https://cs.stackexchange.com/questions/97998/strassens-matrix-multiplication-algorithm-when-n-is-not-a-power-of-2) would be to pad the matrix with zeros and make the dimensions to be a power of two. 