### PR TITLE
add raisedTo method for PMMatrix

### DIFF
--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -824,6 +824,20 @@ PMMatrix >> qrFactorizationWithPivoting [
 	^ Array with: q with: r with: pivot
 ]
 
+{ #category : #operation }
+PMMatrix >> raisedTo: anInteger [
+
+	" Answers the receiver raised to a power anInteger.
+	 If anInteger is negative, inverse of the receiver is raised to the absolute value of anInteger."
+	self assert: self numberOfRows = self numberOfColumns description: 'Matrix should be square'.
+	
+	 anInteger <= 0 ifTrue: [ 
+		anInteger = 0 ifTrue: [^ PMMatrix identity: self numberOfRows ]
+		ifFalse: [ ^ self inverse raisedTo: anInteger abs ]
+		]
+	ifFalse: [ ^ self * (self raisedTo: anInteger -1) ]
+]
+
 { #category : #'as yet unclassified' }
 PMMatrix >> rank [ 
 	^	((self numberOfRows < self numberOfColumns 

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -825,17 +825,21 @@ PMMatrix >> qrFactorizationWithPivoting [
 ]
 
 { #category : #operation }
-PMMatrix >> raisedTo: anInteger [
+PMMatrix >> raisedTo: aPower [
 
-	" Answers the receiver raised to a power anInteger.
-	 If anInteger is negative, inverse of the receiver is raised to the absolute value of anInteger."
-	self assert: self numberOfRows = self numberOfColumns description: 'Matrix should be square'.
+	" Answers the receiver raised to a power, aPower .
+	 If aPower is negative, inverse of the receiver is raised to the absolute value of aPower."
+
+	self assert: self isSquare description: 'Matrix should be square'.
 	
-	 anInteger <= 0 ifTrue: [ 
-		anInteger = 0 ifTrue: [^ PMMatrix identity: self numberOfRows ]
-		ifFalse: [ ^ self inverse raisedTo: anInteger abs ]
-		]
-	ifFalse: [ ^ self * (self raisedTo: anInteger -1) ]
+	 aPower = 0 ifTrue: [ 
+		^ PMMatrix identity: self numberOfRows ].
+	
+	aPower > 0 ifTrue: [
+		^ self * (self raisedTo: aPower -1) ].
+	
+	"aPower is less than 0, if it reaches here"
+	^ self inverse raisedTo: aPower abs
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -829,17 +829,20 @@ PMMatrix >> raisedTo: aPower [
 
 	" Answers the receiver raised to a power, aPower .
 	 If aPower is negative, inverse of the receiver is raised to the absolute value of aPower."
+	
+	|aRaisedPMMatrix|
 
 	self assert: self isSquare description: 'Matrix should be square'.
 	
-	 aPower = 0 ifTrue: [ 
-		^ PMMatrix identity: self numberOfRows ].
+	aPower < 0 ifTrue: [
+		^ self inverse raisedTo: aPower abs ].
 	
-	aPower > 0 ifTrue: [
-		^ self * (self raisedTo: aPower -1) ].
+	aRaisedPMMatrix := PMMatrix identity: self numberOfRows.
 	
-	"aPower is less than 0, if it reaches here"
-	^ self inverse raisedTo: aPower abs
+	1 to: aPower do: [ :each |
+		aRaisedPMMatrix := aRaisedPMMatrix * self ].
+	
+	^ aRaisedPMMatrix 
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -632,6 +632,56 @@ PMMatrixTest >> testPrintOn [
 	m printOn: stream
 ]
 
+{ #category : #tests }
+PMMatrixTest >> testRaisedToNegativeInteger [  
+
+	|aPMMatrix expected|
+	
+	aPMMatrix := PMMatrix rows: #(#(3 1) #(1 1)).
+	
+	aPMMatrix := aPMMatrix raisedTo: -2.
+	expected := PMMatrix rows: #(#(0.5 -1) #(-1 2.5)).
+	
+	self assert: aPMMatrix equals: expected.
+]
+
+{ #category : #tests }
+PMMatrixTest >> testRaisedToNonSquareMatrix [
+
+	|aPMMatrix|
+	
+	aPMMatrix := PMMatrix rows: #(#(3 1 4) #(1 1 2)).
+	
+	self should: [ aPMMatrix raisedTo: 3 ] raise: AssertionFailure.
+	
+]
+
+{ #category : #tests }
+PMMatrixTest >> testRaisedToPositiveInteger [ 
+
+	|aPMMatrix expected|
+	
+	aPMMatrix := PMMatrix rows: #(#(3 1) #(1 1)).
+	
+	aPMMatrix := aPMMatrix raisedTo: 3.
+	expected := PMMatrix rows: #(#(34 14) #(14 6)).
+	
+	self assert: aPMMatrix equals: expected.
+]
+
+{ #category : #tests }
+PMMatrixTest >> testRaisedToZero [
+
+	|aPMMatrix expected|
+	
+	aPMMatrix := PMMatrix rows: #(#(3 1) #(1 1)).
+	
+	aPMMatrix := aPMMatrix raisedTo: 0.
+	expected := aPMMatrix.
+	
+	self assert: aPMMatrix equals: expected.
+]
+
 { #category : #comparing }
 PMMatrixTest >> testRowsColumns [
 	| a |

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -640,8 +640,8 @@ PMMatrixTest >> testRaisedToNegativeInteger [
 	aPMMatrix := PMMatrix rows: #(#(3 1) #(1 1)).
 	
 	aPMMatrix := aPMMatrix raisedTo: -2.
-	expected := PMMatrix rows: #(#(0.5 -1) #(-1 2.5)).
 	
+	expected := PMMatrix rows: #(#(0.5 -1) #(-1 2.5)).
 	self assert: aPMMatrix equals: expected.
 ]
 
@@ -664,8 +664,8 @@ PMMatrixTest >> testRaisedToPositiveInteger [
 	aPMMatrix := PMMatrix rows: #(#(3 1) #(1 1)).
 	
 	aPMMatrix := aPMMatrix raisedTo: 3.
-	expected := PMMatrix rows: #(#(34 14) #(14 6)).
 	
+	expected := PMMatrix rows: #(#(34 14) #(14 6)).
 	self assert: aPMMatrix equals: expected.
 ]
 
@@ -677,8 +677,8 @@ PMMatrixTest >> testRaisedToZero [
 	aPMMatrix := PMMatrix rows: #(#(3 1) #(1 1)).
 	
 	aPMMatrix := aPMMatrix raisedTo: 0.
-	expected := aPMMatrix.
 	
+	expected := PMMatrix rows: #( #(1 0) #(0 1)).
 	self assert: aPMMatrix equals: expected.
 ]
 


### PR DESCRIPTION
A `raisedTo: anInteger` method is added for PMMatrix. Now, exponentiation of matrices can be performed using this method.

Eg: You can calculate A<sup>3</sup> using `A raisedTo: 3`.