### PR TITLE
fix #207 in cholesky decomposition

### DIFF
--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -366,15 +366,20 @@ PMMatrix >> choleskyDecomposition [
 
 					diagonalValue := ((self at: j at: j) - rowSum) sqrt.
 
+
 					upperTriangular at: j at: j put: diagonalValue ]
 				ifFalse: [
-					partialSum := (1 to: j - 1) inject: 0 into: [ :sum :k |
-						sum + (upperTriangular at: k at: i) * (upperTriangular at: k at: j) ].
 
+					partialSum := (1 to: j - 1) inject: 0 into: [ :sum :k |
+							sum + ((upperTriangular at: k at: i) * (upperTriangular at: k at: j)).
+						].
+					
 					factor := upperTriangular at: j at: j.
 					nonDiagonalValue := ((self at: j at: i) - partialSum) / factor.
 
-					upperTriangular at: j at: i put: nonDiagonalValue ] ] ].
+					upperTriangular at: j at: i put: nonDiagonalValue.
+					
+				] ] ].
 		
 	^ upperTriangular
 ]

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -76,16 +76,20 @@ PMMatrixTest >> testCholeskyDecomposition [
 	| matrix upperTriangular expected |
 	
 	matrix := PMMatrix rows: #(
-		(4 12 -16)
-		(12 37 -43)
-		(-16 -43 98)).
+		(4 20 8 2 18)
+		(20 116 80 18 126)
+		(8 80 117 32 135)
+		(2 18 32 73 109)
+		(18 126 135 109 272)).
 		
 	upperTriangular := matrix choleskyDecomposition.
 	
 	expected := PMMatrix rows: #(
-		(2 6 -8)
-		(0 1 5)
-		(0 0 3)).
+		(2 10 4 1 9)
+		(0 4 10 2 9)
+		(0 0 1 8 9)
+		(0 0 0 2 5)
+		(0 0 0 0 2)).
 		
 	self assert: upperTriangular equals: expected.
 ]


### PR DESCRIPTION
## Issue
Fixes #207
A precedence error in the binary block of `#inject:into` was causing Cholesky decomposition to fail for matrices of size more than 3.
## Code before
```
[ sum+ (upperTriangular at: k at: i) * (upperTriangular at: k at: j) ]
```
 where `sum + (upperTriangular at: k at: i)` was being calculated first

## Why did tests pass before
In the tests, the matrix size was 3. 
So, the value of `sum` was always zero, hence the precedence did not matter.

## Change introduced
- Parenthesis has been added to take care of the precedence order
- New tests with a matrix size of more than 3 have been added