### PR TITLE
Refactor complex number tests: Break up testEquality and Introduce Equivalence Relation Contract and Other Tests

### DIFF
--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -4,6 +4,12 @@ Class {
 	#category : #'Math-Tests-Complex'
 }
 
+{ #category : #'testing - equality' }
+PMComplexTest >> testAPureImaginaryNumberIsNotEqualToZero [
+	self deny: 1 i equals: 0.
+	self deny: 0 equals: 1 i.
+]
+
 { #category : #tests }
 PMComplexTest >> testAbs [
 	"self run: #testAbs"
@@ -329,8 +335,6 @@ PMComplexTest >> testEquality [
 	self deny: nil = 1 i.
 	self deny: 1 i = #(1 2 3).
 	self deny: #(1 2 3) = 1 i.
-	self deny: 1 i = 0.
-	self deny: 0 = 1 i.
 ]
 
 { #category : #'testing - equality' }

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -320,7 +320,6 @@ PMComplexTest >> testEquality [
 	"self debug: #testEquality"
 
 	self assert: 0 i equals: 0.
-	self assert: 2 - 5 i equals: 1 - 4 i + (1 - 1 i).
 	self assert: 0 i isZero.
 	self deny: 1 + 3 i = 1.
 

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -794,6 +794,15 @@ PMComplexTest >> testTimesPolynomial [
 	self assert: (poly * c at: 0) equals: c
 ]
 
+{ #category : #'testing - equality' }
+PMComplexTest >> testTwoComplexNumbersWithDifferentRealPartsAreNotEqual [
+	| z w |
+ 	z := 4 + 3 i.
+ 	w := -7 + 3 i.
+
+ 	self deny: z equals: w.
+]
+
 { #category : #'testing - expressing complex numbers' }
 PMComplexTest >> testWeCanWriteComplexNumbersWhoseRealAndImaginaryPartsAreFractions [
 	| z |

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -319,8 +319,6 @@ PMComplexTest >> testEquality [
 
 	"self debug: #testEquality"
 
-	self assert: 0 i equals: 0.
-	self assert: 0 i isZero.
 	self deny: 1 + 3 i = 1.
 
 	"Some more stuff"
@@ -850,4 +848,10 @@ PMComplexTest >> testZero [
 	self assert: z isComplexNumber.
 	self assert: z real isZero.
 	self assert: z imaginary isZero.
+]
+
+{ #category : #'testing - equality' }
+PMComplexTest >> testZeroComplexNumberIsEqualToIntegerZero [
+	self assert: 0 i equals: 0.
+ 	self assert: 0 equals: 0 i.
 ]

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -313,7 +313,7 @@ PMComplexTest >> testDivision1 [
 
 ]
 
-{ #category : #testing }
+{ #category : #'testing - equality' }
 PMComplexTest >> testEquality [
 	"self run: #testEquality"
 
@@ -750,7 +750,7 @@ PMComplexTest >> testTimesPolynomial [
 	self assert: (poly * c at: 0) equals: c
 ]
 
-{ #category : #'expressing complex numbers' }
+{ #category : #'testing - expressing complex numbers' }
 PMComplexTest >> testWeCanWriteComplexNumbersWhoseRealAndImaginaryPartsAreFractions [
 	| z |
 	z := PMComplex real: 3 / 5 imaginary: 4 / 5.
@@ -759,7 +759,7 @@ PMComplexTest >> testWeCanWriteComplexNumbersWhoseRealAndImaginaryPartsAreFracti
 	self assert: (z imaginary) equals: (Fraction numerator: 4 denominator: 5).
 ]
 
-{ #category : #'expressing complex numbers' }
+{ #category : #'testing - expressing complex numbers' }
 PMComplexTest >> testWeCannotWriteFractionsOfComplexNumbersWithDenominatorNormalized [
 
 	| z w numerator denominator |
@@ -771,7 +771,7 @@ PMComplexTest >> testWeCannotWriteFractionsOfComplexNumbersWithDenominatorNormal
 	self should: [ Fraction numerator: numerator denominator: w squaredNorm ] raise: Exception.
 ]
 
-{ #category : #'expressing complex numbers' }
+{ #category : #'testing - expressing complex numbers' }
 PMComplexTest >> testWeCannotWriteFractionsWhoseNumeratorAndDenominatorAreComplexNumbers [
 	| numerator denominator |
 	"It is interesting that we cannot instanciate a fraction of the form z/w"

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -344,19 +344,19 @@ PMComplexTest >> testEqualsIsSymmetric [
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testEqualsIsSymmetricWithComplexNumbersAndIntegers [
-	self assert: 1 + 0 i equals: 1.
-	self assert: 1 equals: 1 + 0 i.
-]
-
-{ #category : #'testing - equality' }
-PMComplexTest >> testEqualsIsSymmetricWithFractions [
+PMComplexTest >> testEqualsIsSymmetricWithRespectToFractions [
 	self assert: 1 / 2 + 0 i equals: 1 / 2.
 	self assert: 1 / 2 equals: 1 / 2 + 0 i
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testEqualsIsSymmetricWithRealNumbers [
+PMComplexTest >> testEqualsIsSymmetricWithRespectToIntegers [
+	self assert: 1 + 0 i equals: 1.
+	self assert: 1 equals: 1 + 0 i.
+]
+
+{ #category : #'testing - equality' }
+PMComplexTest >> testEqualsIsSymmetricWithRespectToRealNumbers [
 	self assert: 1 + 0 i equals: 1.0.
 	self assert: 1.0 equals: 1 + 0 i.
 ]

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -332,8 +332,6 @@ PMComplexTest >> testEquality [
 	self deny: #(1 2 3) = 1 i.
 	self deny: 1 i = 0.
 	self deny: 0 = 1 i.
-	self assert: 1 + 0 i equals: 1.
-	self assert: 1 equals: 1 + 0 i.
 	self assert: 1 + 0 i equals: 1.0.
 	self assert: 1.0 equals: 1 + 0 i.
 	self assert: 1 / 2 + 0 i equals: 1 / 2.
@@ -357,6 +355,12 @@ PMComplexTest >> testEqualsIsSymmetric [
 
  	self assert: z equals: w.
  	self assert: w equals: z.
+]
+
+{ #category : #'testing - equality' }
+PMComplexTest >> testEqualsIsSymmetricWithComplexNumbersAndIntegers [
+	self assert: 1 + 0 i equals: 1.
+	self assert: 1 equals: 1 + 0 i.
 ]
 
 { #category : #'testing - equality' }

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -323,7 +323,6 @@ PMComplexTest >> testEquality [
 	self assert: 2 - 5 i equals: 1 - 4 i + (1 - 1 i).
 	self assert: 0 i isZero.
 	self deny: 1 + 3 i = 1.
-	self deny: 1 + 3 i = (1 + 2 i).
 
 	"Some more stuff"
 	self deny: 1 i = nil.
@@ -792,6 +791,15 @@ PMComplexTest >> testTimesPolynomial [
 	poly := PMPolynomial coefficients: #(1).
 	self assert: (c * poly at: 0) equals: c.
 	self assert: (poly * c at: 0) equals: c
+]
+
+{ #category : #'testing - equality' }
+PMComplexTest >> testTwoComplexNumbersWithDifferentImaginaryPartsAreNotEqual [
+	| z w |
+ 	z := 1 + 3 i.
+ 	w := 1 + 2 i.
+
+ 	self deny: z equals: w.
 ]
 
 { #category : #'testing - equality' }

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -332,14 +332,10 @@ PMComplexTest >> testEquality [
 	self deny: #(1 2 3) = 1 i.
 	self deny: 1 i = 0.
 	self deny: 0 = 1 i.
-	self assert: 1 + 0 i equals: 1.0.
-	self assert: 1.0 equals: 1 + 0 i.
-	self assert: 1 / 2 + 0 i equals: 1 / 2.
-	self assert: 1 / 2 equals: 1 / 2 + 0 i
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testEqualsIsReflexive [ 
+PMComplexTest >> testEqualsIsReflexive [
 	| z |
  	z := -10 + 10 i.
 
@@ -361,6 +357,18 @@ PMComplexTest >> testEqualsIsSymmetric [
 PMComplexTest >> testEqualsIsSymmetricWithComplexNumbersAndIntegers [
 	self assert: 1 + 0 i equals: 1.
 	self assert: 1 equals: 1 + 0 i.
+]
+
+{ #category : #'testing - equality' }
+PMComplexTest >> testEqualsIsSymmetricWithFractions [
+	self assert: 1 / 2 + 0 i equals: 1 / 2.
+	self assert: 1 / 2 equals: 1 / 2 + 0 i
+]
+
+{ #category : #'testing - equality' }
+PMComplexTest >> testEqualsIsSymmetricWithRealNumbers [
+	self assert: 1 + 0 i equals: 1.0.
+	self assert: 1.0 equals: 1 + 0 i.
 ]
 
 { #category : #'testing - equality' }

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -340,6 +340,38 @@ PMComplexTest >> testEquality [
 	self assert: 1 / 2 equals: 1 / 2 + 0 i
 ]
 
+{ #category : #'testing - equality' }
+PMComplexTest >> testEqualsIsReflexive [ 
+	| z |
+ 	z := -10 + 10 i.
+
+ 	self assert: z equals: z.
+]
+
+{ #category : #'testing - equality' }
+PMComplexTest >> testEqualsIsSymmetric [
+	| z w |
+
+ 	z := 13 + 14 i.
+ 	w := 13 + 14 i.
+
+ 	self assert: z equals: w.
+ 	self assert: w equals: z.
+]
+
+{ #category : #'testing - equality' }
+PMComplexTest >> testEqualsIsTransitive [
+	| z w u |
+
+ 	z := 4 - 1 i.
+ 	w := 4 - 1 i.
+ 	u := 4 - 1 i.
+
+ 	self assert: z equals: w.
+ 	self assert: w equals: u.
+ 	self assert: z equals: u.
+]
+
 { #category : #tests }
 PMComplexTest >> testFloatClass [
 	"just make sure it's implemented"

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -204,6 +204,11 @@ PMComplexTest >> testComplexConjugate [
 	self assert: complexConjugateOfZ equals: expected.
 ]
 
+{ #category : #'testing - equality' }
+PMComplexTest >> testComplexNumberAndIntegerAreUnequalEvenIfRealPartIsEqualToInteger [
+	self deny: 1 + 3 i equals: 1.
+]
+
 { #category : #tests }
 PMComplexTest >> testConversion [
 	"self run: #testConversion"
@@ -318,8 +323,6 @@ PMComplexTest >> testEquality [
 	"self run: #testEquality"
 
 	"self debug: #testEquality"
-
-	self deny: 1 + 3 i = 1.
 
 	"Some more stuff"
 	self deny: 1 i = nil.

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -325,19 +325,6 @@ PMComplexTest >> testDivision1 [
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testEquality [
-	"self run: #testEquality"
-
-	"self debug: #testEquality"
-
-	"Some more stuff"
-	self deny: 1 i = nil.
-	self deny: nil = 1 i.
-	self deny: 1 i = #(1 2 3).
-	self deny: #(1 2 3) = 1 i.
-]
-
-{ #category : #'testing - equality' }
 PMComplexTest >> testEqualsIsReflexive [
 	| z |
  	z := -10 + 10 i.
@@ -556,6 +543,14 @@ PMComplexTest >> testProductWithVector [
 	v at: 1 put: 1.
 	self assert: (v * c at: 1) equals: c.
 	self assert: (c * v at: 1) equals: c
+]
+
+{ #category : #'testing - equality' }
+PMComplexTest >> testPureImaginaryNumbersAreNotEqualToObjectsOfADifferentType [ 
+	self deny: 1 i = nil.
+	self deny: nil = 1 i.
+	self deny: 1 i = #(1 2 3).
+	self deny: #(1 2 3) = 1 i.
 ]
 
 { #category : #tests }


### PR DESCRIPTION
As part of issue #192, replaced a long unclear test with specific and clearly named tests for equality. 