### PR TITLE
Refactor testFFT

### DIFF
--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -57,8 +57,8 @@ PMFFTTest >> testFastFourierTransformDoesNotLoseAnySignal [
 	f inverseTransform.
 	
 	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
-	self assert: zeroedImaginaryData equals: 256.
 	zeroedRealData := (f realData - cosineWaveSignal select: [ :i | i equalsTo: 0 ]) size.
+	self assert: zeroedImaginaryData equals: 256.
 	self assert: zeroedRealData equals: 256.
 	
 	PMMitchellMooreGenerator reset: 1.

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -22,7 +22,7 @@ PMFFTTest >> testBitReverse [
 
 { #category : #tests }
 PMFFTTest >> testFFT [
-	| data data1 f s |
+	| data f s |
 	data := (1 to: 256)
 		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
 	data := #(-2 -2 -2 3 3 3 1 -2).
@@ -64,7 +64,7 @@ PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithou
 
 { #category : #tests }
 PMFFTTest >> testFastFourierTransformOutputSignalMatchesInputSignalClosely [
-	| data data1 f s |
+	| data data1 f |
 	data := (1 to: 256)
 		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
 	data1 := data collect: [ :i | i + 0.001 random - 0.0005 ].

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -30,9 +30,8 @@ PMFFTTest >> testBitReverse [
 { #category : #tests }
 PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithoutLossOfSignalForLargeDataSets [
 
-	| cosineWaveSignal f zeroedImaginaryData zeroedRealData inputOutputDiff sampleSize |
-	sampleSize := 256.
-	cosineWaveSignal := self generateCosineWaveSignal: sampleSize.
+	| cosineWaveSignal f zeroedImaginaryData zeroedRealData inputOutputDiff |
+	cosineWaveSignal := self generateCosineWaveSignal: 256.
 	f := PMFastFourierTransform data: cosineWaveSignal.
 
 	f transform.
@@ -43,8 +42,8 @@ PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithou
 	inputOutputDiff := f realData - cosineWaveSignal.
 	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ])
 		                  size.
-	self assert: zeroedImaginaryData equals: sampleSize.
-	self assert: zeroedRealData equals: sampleSize.
+	self assert: zeroedImaginaryData equals: 256.
+	self assert: zeroedRealData equals: 256.
 
 	PMMitchellMooreGenerator reset: 1
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -25,14 +25,6 @@ PMFFTTest >> testFFT [
 	| data data1 f s |
 	data := (1 to: 256)
 		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
-	f := PMFastFourierTransform data: data.
-	f transform.
-	f inverseTransform.
-	s := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
-	self assert: s equals: 256.
-	s := (f realData - data select: [ :i | i equalsTo: 0 ]) size.
-	self assert: s equals: 256.
-	PMMitchellMooreGenerator reset: 1.
 	data1 := data collect: [ :i | i + 0.001 random - 0.0005 ].
 	f := PMFastFourierTransform data: data1.
 	f transform.
@@ -52,4 +44,19 @@ PMFFTTest >> testFFT [
 	self assert: s equals: 8.
 	s := (f realData - data select: [ :i | i equalsTo: 0 ]) size.
 	self assert: s equals: 8
+]
+
+{ #category : #tests }
+PMFFTTest >> testFastFourierTransformDoesNotLoseAnySignal [
+	| data f s |
+	data := (1 to: 256)
+		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
+	f := PMFastFourierTransform data: data.
+	f transform.
+	f inverseTransform.
+	s := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
+	self assert: s equals: 256.
+	s := (f realData - data select: [ :i | i equalsTo: 0 ]) size.
+	self assert: s equals: 256.
+	PMMitchellMooreGenerator reset: 1.
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -48,14 +48,14 @@ PMFFTTest >> testFFT [
 
 { #category : #tests }
 PMFFTTest >> testFastFourierTransformDoesNotLoseAnySignal [
-	| cosineWaveSignal f s |
+	| cosineWaveSignal f s zeroedImaginaryData |
 	cosineWaveSignal := (1 to: 256)
 		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
 	f := PMFastFourierTransform data: cosineWaveSignal.
 	f transform.
 	f inverseTransform.
-	s := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
-	self assert: s equals: 256.
+	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
+	self assert: zeroedImaginaryData equals: 256.
 	s := (f realData - cosineWaveSignal select: [ :i | i equalsTo: 0 ]) size.
 	self assert: s equals: 256.
 	PMMitchellMooreGenerator reset: 1.

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -54,9 +54,9 @@ PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithou
 
 	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ])
 		                       size.
-	self assert: zeroedImaginaryData equals: 8.
 	inputOutputDiff := f realData - inputSignal.
 	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]) size.
+	self assert: zeroedImaginaryData equals: 8.
 	self assert: zeroedRealData equals: 8
 ]
 

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -25,11 +25,6 @@ PMFFTTest >> testFFT [
 	| inputSignal f s |
 	inputSignal := #(-2 -2 -2 3 3 3 1 -2).
 	f := PMFastFourierTransform data: inputSignal.
-	f chop: 1.01.
-	self assert: f realData equals: #(-2 -2 -2 3 3 3 0 -2).
-	f chop: 2.01.
-	self assert: f realData equals: #(0 0 0 3 3 3 0 0).
-	f data: inputSignal.
 	f transform.
 	f inverseTransform.
 	s := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -25,8 +25,10 @@ PMFFTTest >> testFFT [
 	| inputSignal f s |
 	inputSignal := #(-2 -2 -2 3 3 3 1 -2).
 	f := PMFastFourierTransform data: inputSignal.
+	
 	f transform.
 	f inverseTransform.
+	
 	s := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
 	self assert: s equals: 8.
 	s := (f realData - inputSignal select: [ :i | i equalsTo: 0 ]) size.

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -21,22 +21,7 @@ PMFFTTest >> testBitReverse [
 ]
 
 { #category : #tests }
-PMFFTTest >> testFFT [
-	| inputSignal f s |
-	inputSignal := #(-2 -2 -2 3 3 3 1 -2).
-	f := PMFastFourierTransform data: inputSignal.
-	
-	f transform.
-	f inverseTransform.
-	
-	s := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
-	self assert: s equals: 8.
-	s := (f realData - inputSignal select: [ :i | i equalsTo: 0 ]) size.
-	self assert: s equals: 8
-]
-
-{ #category : #tests }
-PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithoutLossOfSignal [
+PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithoutLossOfSignalForLargeDataSets [
 
 	| cosineWaveSignal f zeroedImaginaryData zeroedRealData inputOutputDiff |
 	cosineWaveSignal := (1 to: 256) collect: [ :i | 
@@ -55,6 +40,21 @@ PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithou
 	self assert: zeroedRealData equals: 256.
 
 	PMMitchellMooreGenerator reset: 1
+]
+
+{ #category : #tests }
+PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithoutLossOfSignalForSmallDataSets [
+	| inputSignal f s |
+	inputSignal := #(-2 -2 -2 3 3 3 1 -2).
+	f := PMFastFourierTransform data: inputSignal.
+	
+	f transform.
+	f inverseTransform.
+	
+	s := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
+	self assert: s equals: 8.
+	s := (f realData - inputSignal select: [ :i | i equalsTo: 0 ]) size.
+	self assert: s equals: 8
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -23,8 +23,6 @@ PMFFTTest >> testBitReverse [
 { #category : #tests }
 PMFFTTest >> testFFT [
 	| data f s |
-	data := (1 to: 256)
-		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
 	data := #(-2 -2 -2 3 3 3 1 -2).
 	f := PMFastFourierTransform data: data.
 	f chop: 1.01.
@@ -69,8 +67,10 @@ PMFFTTest >> testFastFourierTransformOutputSignalMatchesRandomizedInputSignalClo
 		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
 	randomizedCosineWaveSignal := cosineWaveSignal collect: [ :i | i + 0.001 random - 0.0005 ].
 	f := PMFastFourierTransform data: randomizedCosineWaveSignal.
+	
 	f transform.
 	f chop: 0.01.
 	f inverseTransform.
+	
 	self assert: (f realData - cosineWaveSignal) abs max < 4e-5.
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -22,19 +22,19 @@ PMFFTTest >> testBitReverse [
 
 { #category : #tests }
 PMFFTTest >> testFFT [
-	| data f s |
-	data := #(-2 -2 -2 3 3 3 1 -2).
-	f := PMFastFourierTransform data: data.
+	| inputSignal f s |
+	inputSignal := #(-2 -2 -2 3 3 3 1 -2).
+	f := PMFastFourierTransform data: inputSignal.
 	f chop: 1.01.
 	self assert: f realData equals: #(-2 -2 -2 3 3 3 0 -2).
 	f chop: 2.01.
 	self assert: f realData equals: #(0 0 0 3 3 3 0 0).
-	f data: data.
+	f data: inputSignal.
 	f transform.
 	f inverseTransform.
 	s := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
 	self assert: s equals: 8.
-	s := (f realData - data select: [ :i | i equalsTo: 0 ]) size.
+	s := (f realData - inputSignal select: [ :i | i equalsTo: 0 ]) size.
 	self assert: s equals: 8
 ]
 

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -48,15 +48,15 @@ PMFFTTest >> testFFT [
 
 { #category : #tests }
 PMFFTTest >> testFastFourierTransformDoesNotLoseAnySignal [
-	| data f s |
-	data := (1 to: 256)
+	| cosineWaveSignal f s |
+	cosineWaveSignal := (1 to: 256)
 		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
-	f := PMFastFourierTransform data: data.
+	f := PMFastFourierTransform data: cosineWaveSignal.
 	f transform.
 	f inverseTransform.
 	s := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
 	self assert: s equals: 256.
-	s := (f realData - data select: [ :i | i equalsTo: 0 ]) size.
+	s := (f realData - cosineWaveSignal select: [ :i | i equalsTo: 0 ]) size.
 	self assert: s equals: 256.
 	PMMitchellMooreGenerator reset: 1.
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -63,14 +63,14 @@ PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithou
 ]
 
 { #category : #tests }
-PMFFTTest >> testFastFourierTransformOutputSignalMatchesInputSignalClosely [
-	| data data1 f |
-	data := (1 to: 256)
+PMFFTTest >> testFastFourierTransformOutputSignalMatchesRandomizedInputSignalClosely [
+	| cosineWaveSignal randomizedCosineWaveSignal f |
+	cosineWaveSignal := (1 to: 256)
 		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
-	data1 := data collect: [ :i | i + 0.001 random - 0.0005 ].
-	f := PMFastFourierTransform data: data1.
+	randomizedCosineWaveSignal := cosineWaveSignal collect: [ :i | i + 0.001 random - 0.0005 ].
+	f := PMFastFourierTransform data: randomizedCosineWaveSignal.
 	f transform.
 	f chop: 0.01.
 	f inverseTransform.
-	self assert: (f realData - data) abs max < 4e-5.
+	self assert: (f realData - cosineWaveSignal) abs max < 4e-5.
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -44,15 +44,15 @@ PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithou
 
 { #category : #tests }
 PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithoutLossOfSignalForSmallDataSets [
-	| inputSignal f s |
+	| inputSignal f s zeroedImaginaryData |
 	inputSignal := #(-2 -2 -2 3 3 3 1 -2).
 	f := PMFastFourierTransform data: inputSignal.
 	
 	f transform.
 	f inverseTransform.
 	
-	s := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
-	self assert: s equals: 8.
+	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
+	self assert: zeroedImaginaryData equals: 8.
 	s := (f realData - inputSignal select: [ :i | i equalsTo: 0 ]) size.
 	self assert: s equals: 8
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -44,17 +44,20 @@ PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithou
 
 { #category : #tests }
 PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithoutLossOfSignalForSmallDataSets [
-	| inputSignal f s zeroedImaginaryData |
-	inputSignal := #(-2 -2 -2 3 3 3 1 -2).
+
+	| inputSignal f zeroedImaginaryData inputOutputDiff zeroedRealData |
+	inputSignal := #( -2 -2 -2 3 3 3 1 -2 ).
 	f := PMFastFourierTransform data: inputSignal.
-	
+
 	f transform.
 	f inverseTransform.
-	
-	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
+
+	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ])
+		                       size.
 	self assert: zeroedImaginaryData equals: 8.
-	s := (f realData - inputSignal select: [ :i | i equalsTo: 0 ]) size.
-	self assert: s equals: 8
+	inputOutputDiff := f realData - inputSignal.
+	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]) size.
+	self assert: zeroedRealData equals: 8
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -52,11 +52,14 @@ PMFFTTest >> testFastFourierTransformDoesNotLoseAnySignal [
 	cosineWaveSignal := (1 to: 256)
 		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
 	f := PMFastFourierTransform data: cosineWaveSignal.
+	
 	f transform.
 	f inverseTransform.
+	
 	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
 	self assert: zeroedImaginaryData equals: 256.
 	zeroedRealData := (f realData - cosineWaveSignal select: [ :i | i equalsTo: 0 ]) size.
 	self assert: zeroedRealData equals: 256.
+	
 	PMMitchellMooreGenerator reset: 1.
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -48,18 +48,22 @@ PMFFTTest >> testFFT [
 
 { #category : #tests }
 PMFFTTest >> testFastFourierTransformDoesNotLoseAnySignal [
-	| cosineWaveSignal f zeroedImaginaryData zeroedRealData |
-	cosineWaveSignal := (1 to: 256)
-		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
+
+	| cosineWaveSignal f zeroedImaginaryData zeroedRealData inputOutputDiff |
+	cosineWaveSignal := (1 to: 256) collect: [ :i | 
+		                    (Float pi * (i - 1) / (256 / 8)) cos ].
 	f := PMFastFourierTransform data: cosineWaveSignal.
-	
+
 	f transform.
 	f inverseTransform.
-	
-	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
-	zeroedRealData := (f realData - cosineWaveSignal select: [ :i | i equalsTo: 0 ]) size.
+
+	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ])
+		                       size.
+	inputOutputDiff := f realData - cosineWaveSignal.
+	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ])
+		                  size.
 	self assert: zeroedImaginaryData equals: 256.
 	self assert: zeroedRealData equals: 256.
-	
-	PMMitchellMooreGenerator reset: 1.
+
+	PMMitchellMooreGenerator reset: 1
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -5,6 +5,13 @@ Class {
 }
 
 { #category : #tests }
+PMFFTTest >> generateCosineWaveSignal: sampleSize [
+
+	^ (1 to: sampleSize) collect: [ :i | 
+		  (Float pi * (i - 1) / (sampleSize / 8)) cos ]
+]
+
+{ #category : #tests }
 PMFFTTest >> testBitReverse [
 	self should: [ 1 bitReverse: 0 ] raise: Error.
 	self should: [ 2 bitReverse: 1 ] raise: Error.
@@ -23,9 +30,9 @@ PMFFTTest >> testBitReverse [
 { #category : #tests }
 PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithoutLossOfSignalForLargeDataSets [
 
-	| cosineWaveSignal f zeroedImaginaryData zeroedRealData inputOutputDiff |
-	cosineWaveSignal := (1 to: 256) collect: [ :i | 
-		                    (Float pi * (i - 1) / (256 / 8)) cos ].
+	| cosineWaveSignal f zeroedImaginaryData zeroedRealData inputOutputDiff sampleSize |
+	sampleSize := 256.
+	cosineWaveSignal := self generateCosineWaveSignal: sampleSize.
 	f := PMFastFourierTransform data: cosineWaveSignal.
 
 	f transform.
@@ -36,8 +43,8 @@ PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithou
 	inputOutputDiff := f realData - cosineWaveSignal.
 	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ])
 		                  size.
-	self assert: zeroedImaginaryData equals: 256.
-	self assert: zeroedRealData equals: 256.
+	self assert: zeroedImaginaryData equals: sampleSize.
+	self assert: zeroedRealData equals: sampleSize.
 
 	PMMitchellMooreGenerator reset: 1
 ]
@@ -62,17 +69,18 @@ PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithou
 
 { #category : #tests }
 PMFFTTest >> testFastFourierTransformOutputSignalMatchesRandomizedInputSignalClosely [
+
 	| cosineWaveSignal randomizedCosineWaveSignal f |
-	cosineWaveSignal := (1 to: 256)
-		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
-	randomizedCosineWaveSignal := cosineWaveSignal collect: [ :i | i + 0.001 random - 0.0005 ].
+	cosineWaveSignal := self generateCosineWaveSignal: 256.
+	randomizedCosineWaveSignal := cosineWaveSignal collect: [ :i | 
+		                              i + 0.001 random - 0.0005 ].
 	f := PMFastFourierTransform data: randomizedCosineWaveSignal.
-	
+
 	f transform.
 	f chop: 0.01.
 	f inverseTransform.
-	
-	self assert: (f realData - cosineWaveSignal) abs max < 4e-5.
+
+	self assert: (f realData - cosineWaveSignal) abs max < 4e-5
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -48,7 +48,7 @@ PMFFTTest >> testFFT [
 
 { #category : #tests }
 PMFFTTest >> testFastFourierTransformDoesNotLoseAnySignal [
-	| cosineWaveSignal f s zeroedImaginaryData |
+	| cosineWaveSignal f zeroedImaginaryData zeroedRealData |
 	cosineWaveSignal := (1 to: 256)
 		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
 	f := PMFastFourierTransform data: cosineWaveSignal.
@@ -56,7 +56,7 @@ PMFFTTest >> testFastFourierTransformDoesNotLoseAnySignal [
 	f inverseTransform.
 	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
 	self assert: zeroedImaginaryData equals: 256.
-	s := (f realData - cosineWaveSignal select: [ :i | i equalsTo: 0 ]) size.
-	self assert: s equals: 256.
+	zeroedRealData := (f realData - cosineWaveSignal select: [ :i | i equalsTo: 0 ]) size.
+	self assert: zeroedRealData equals: 256.
 	PMMitchellMooreGenerator reset: 1.
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -25,12 +25,6 @@ PMFFTTest >> testFFT [
 	| data data1 f s |
 	data := (1 to: 256)
 		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
-	data1 := data collect: [ :i | i + 0.001 random - 0.0005 ].
-	f := PMFastFourierTransform data: data1.
-	f transform.
-	f chop: 0.01.
-	f inverseTransform.
-	self assert: (f realData - data) abs max < 4e-5.
 	data := #(-2 -2 -2 3 3 3 1 -2).
 	f := PMFastFourierTransform data: data.
 	f chop: 1.01.
@@ -66,4 +60,17 @@ PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithou
 	self assert: zeroedRealData equals: 256.
 
 	PMMitchellMooreGenerator reset: 1
+]
+
+{ #category : #tests }
+PMFFTTest >> testFastFourierTransformOutputSignalMatchesInputSignalClosely [
+	| data data1 f s |
+	data := (1 to: 256)
+		collect: [ :i | (Float pi * (i - 1) / (256 / 8)) cos ].
+	data1 := data collect: [ :i | i + 0.001 random - 0.0005 ].
+	f := PMFastFourierTransform data: data1.
+	f transform.
+	f chop: 0.01.
+	f inverseTransform.
+	self assert: (f realData - data) abs max < 4e-5.
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -47,7 +47,7 @@ PMFFTTest >> testFFT [
 ]
 
 { #category : #tests }
-PMFFTTest >> testFastFourierTransformDoesNotLoseAnySignal [
+PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithoutLossOfSignal [
 
 	| cosineWaveSignal f zeroedImaginaryData zeroedRealData inputOutputDiff |
 	cosineWaveSignal := (1 to: 256) collect: [ :i | 

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -74,3 +74,14 @@ PMFFTTest >> testFastFourierTransformOutputSignalMatchesRandomizedInputSignalClo
 	
 	self assert: (f realData - cosineWaveSignal) abs max < 4e-5.
 ]
+
+{ #category : #tests }
+PMFFTTest >> testThatChopRemovesInputSignalPointsLowerThanTolerance [ 
+	| inputSignal f |
+	inputSignal := #(-2 -2 -2 3 3 3 1 -2).
+	f := PMFastFourierTransform data: inputSignal.
+	f chop: 1.01.
+	self assert: f realData equals: #(-2 -2 -2 3 3 3 0 -2).
+	f chop: 2.01.
+	self assert: f realData equals: #(0 0 0 3 3 3 0 0).
+]


### PR DESCRIPTION
The test method is too long, and this is making it difficult to locate the precise part that is the reason. I've chosen to break it up in order to understand that better. 

Along the way, we have surfaced two tests that are similar, in that they take an input (cosine way or array), compute the discrete Fourier Transfer and check the size of the output signal. Perhaps we can remove the one that tests a large data set without loss of confidence.