### PR TITLE
Refactor FFT tests: Extract Duplicate Code To An Intention-Revealing Custom Assertion

### DIFF
--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -63,11 +63,11 @@ PMFFTTest >> testThatDiscreteFourierTransformDoesNotLoseDataForLargeDataSets [
 	f transform.
 	f inverseTransform.
 
-	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
+	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]).
 	inputOutputDiff := f realData - inputSequence.
-	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]) size.
-	self assert: zeroedImaginaryData equals: inputSequence size.
-	self assert: zeroedRealData equals: inputSequence size.
+	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]).
+	self assert: zeroedImaginaryData size equals: inputSequence size.
+	self assert: zeroedRealData size equals: inputSequence size.
 	
 ]
 
@@ -81,9 +81,9 @@ PMFFTTest >> testThatDiscreteFourierTransformDoesNotLoseDataForSmallDataSets [
 	f transform.
 	f inverseTransform.
 
-	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
+	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]).
 	inputOutputDiff := f realData - inputSequence.
-	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]) size.
-	self assert: zeroedImaginaryData equals: inputSequence size.
-	self assert: zeroedRealData equals: inputSequence size
+	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]).
+	self assert: zeroedImaginaryData size equals: inputSequence size.
+	self assert: zeroedRealData size equals: inputSequence size
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -28,42 +28,6 @@ PMFFTTest >> testBitReverse [
 ]
 
 { #category : #tests }
-PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithoutLossOfSignalForLargeDataSets [
-
-	| inputSequence f zeroedImaginaryData inputOutputDiff zeroedRealData |
-	inputSequence := self generateCosineWaveSignal: 256.
-	f := PMFastFourierTransform data: inputSequence.
-
-	f transform.
-	f inverseTransform.
-
-	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
-	inputOutputDiff := f realData - inputSequence.
-	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]) size.
-	self assert: zeroedImaginaryData equals: 256.
-	self assert: zeroedRealData equals: 256.
-
-	PMMitchellMooreGenerator reset: 1
-]
-
-{ #category : #tests }
-PMFFTTest >> testFastFourierTransformCalculatesTheDiscreteFourierTransformWithoutLossOfSignalForSmallDataSets [
-
-	| inputSequence f zeroedImaginaryData inputOutputDiff zeroedRealData |
-	inputSequence := #( -2 -2 -2 3 3 3 1 -2 ).
-	f := PMFastFourierTransform data: inputSequence.
-
-	f transform.
-	f inverseTransform.
-
-	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
-	inputOutputDiff := f realData - inputSequence.
-	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]) size.
-	self assert: zeroedImaginaryData equals: 8.
-	self assert: zeroedRealData equals: 8
-]
-
-{ #category : #tests }
 PMFFTTest >> testFrequencyDomainRepresentationMatchesRandomizedInputSignalClosely [
 
 	| cosineWaveSignal randomizedCosineWaveSignal f |
@@ -87,4 +51,40 @@ PMFFTTest >> testThatChopSuccessivelyRemovesInputSignalPointsLowerThanTolerance 
 	self assert: f realData equals: #(-2 -2 -2 3 3 3 0 -2).
 	f chop: 2.01.
 	self assert: f realData equals: #(0 0 0 3 3 3 0 0).
+]
+
+{ #category : #tests }
+PMFFTTest >> testThatDiscreteFourierTransformDoesNotLoseDataForLargeDataSets [
+
+	| inputSequence f zeroedImaginaryData inputOutputDiff zeroedRealData |
+	inputSequence := self generateCosineWaveSignal: 256.
+	f := PMFastFourierTransform data: inputSequence.
+
+	f transform.
+	f inverseTransform.
+
+	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
+	inputOutputDiff := f realData - inputSequence.
+	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]) size.
+	self assert: zeroedImaginaryData equals: 256.
+	self assert: zeroedRealData equals: 256.
+
+	PMMitchellMooreGenerator reset: 1
+]
+
+{ #category : #tests }
+PMFFTTest >> testThatDiscreteFourierTransformDoesNotLoseDataForSmallDataSets [
+
+	| inputSequence f zeroedImaginaryData inputOutputDiff zeroedRealData |
+	inputSequence := #( -2 -2 -2 3 3 3 1 -2 ).
+	f := PMFastFourierTransform data: inputSequence.
+
+	f transform.
+	f inverseTransform.
+
+	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
+	inputOutputDiff := f realData - inputSequence.
+	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]) size.
+	self assert: zeroedImaginaryData equals: 8.
+	self assert: zeroedRealData equals: 8
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -5,6 +5,22 @@ Class {
 }
 
 { #category : #tests }
+PMFFTTest >> assertNoDataLossInDiscreteFourierTransferOf: inputSequence [
+
+	| zeroedRealData f zeroedImaginaryData inputOutputDiff |
+	f := PMFastFourierTransform data: inputSequence.
+
+	f transform.
+	f inverseTransform.
+
+	zeroedImaginaryData := f imaginaryData select: [ :i | i equalsTo: 0 ].
+	inputOutputDiff := f realData - inputSequence.
+	zeroedRealData := inputOutputDiff select: [ :i | i equalsTo: 0 ].
+	self assert: zeroedImaginaryData size equals: inputSequence size.
+	self assert: zeroedRealData size equals: inputSequence size
+]
+
+{ #category : #tests }
 PMFFTTest >> generateCosineWaveSignal: sampleSize [
 
 	^ (1 to: sampleSize) collect: [ :i | 
@@ -56,34 +72,15 @@ PMFFTTest >> testThatChopSuccessivelyRemovesInputSignalPointsLowerThanTolerance 
 { #category : #tests }
 PMFFTTest >> testThatDiscreteFourierTransformDoesNotLoseDataForLargeDataSets [
 
-	| inputSequence f zeroedImaginaryData inputOutputDiff zeroedRealData |
+	| inputSequence |
 	inputSequence := self generateCosineWaveSignal: 256.
-	f := PMFastFourierTransform data: inputSequence.
-
-	f transform.
-	f inverseTransform.
-
-	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]).
-	inputOutputDiff := f realData - inputSequence.
-	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]).
-	self assert: zeroedImaginaryData size equals: inputSequence size.
-	self assert: zeroedRealData size equals: inputSequence size.
-	
+	self assertNoDataLossInDiscreteFourierTransferOf: inputSequence
 ]
 
 { #category : #tests }
 PMFFTTest >> testThatDiscreteFourierTransformDoesNotLoseDataForSmallDataSets [
 
-	| inputSequence f zeroedImaginaryData inputOutputDiff zeroedRealData |
-	inputSequence := #( -2 -2 -2 3 3 3 1 -2 ).
-	f := PMFastFourierTransform data: inputSequence.
-
-	f transform.
-	f inverseTransform.
-
-	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]).
-	inputOutputDiff := f realData - inputSequence.
-	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]).
-	self assert: zeroedImaginaryData size equals: inputSequence size.
-	self assert: zeroedRealData size equals: inputSequence size.
+	| inputSequence |
+	inputSequence := #(  -2  -2  -2 3 3 3 1  -2 ).
+	self assertNoDataLossInDiscreteFourierTransferOf: inputSequence
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -5,8 +5,7 @@ Class {
 }
 
 { #category : #asserting }
-PMFFTTest >> assertNoDataLossInDiscreteFourierTransferOf: inputSequence [
-
+PMFFTTest >> assertDiscreteFourierTransformOf: inputSequence hasSize: size [ 
 	| zeroedRealData f zeroedImaginaryData inputOutputDiff |
 	f := PMFastFourierTransform data: inputSequence.
 
@@ -16,8 +15,8 @@ PMFFTTest >> assertNoDataLossInDiscreteFourierTransferOf: inputSequence [
 	zeroedImaginaryData := f imaginaryData select: [ :i | i equalsTo: 0 ].
 	inputOutputDiff := f realData - inputSequence.
 	zeroedRealData := inputOutputDiff select: [ :i | i equalsTo: 0 ].
-	self assert: zeroedImaginaryData size equals: inputSequence size.
-	self assert: zeroedRealData size equals: inputSequence size
+	self assert: zeroedImaginaryData size equals: size.
+	self assert: zeroedRealData size equals: size
 ]
 
 { #category : #tests }
@@ -74,7 +73,7 @@ PMFFTTest >> testThatDiscreteFourierTransformDoesNotLoseDataForLargeDataSets [
 
 	| inputSequence |
 	inputSequence := self generateCosineWaveSignal: 256.
-	self assertNoDataLossInDiscreteFourierTransferOf: inputSequence
+	self assertDiscreteFourierTransformOf: inputSequence hasSize: 256.
 ]
 
 { #category : #tests }
@@ -82,5 +81,5 @@ PMFFTTest >> testThatDiscreteFourierTransformDoesNotLoseDataForSmallDataSets [
 
 	| inputSequence |
 	inputSequence := #(  -2  -2  -2 3 3 3 1  -2 ).
-	self assertNoDataLossInDiscreteFourierTransferOf: inputSequence
+	self assertDiscreteFourierTransformOf: inputSequence hasSize: 8.
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Math-Tests-FastFourierTransform'
 }
 
-{ #category : #tests }
+{ #category : #asserting }
 PMFFTTest >> assertNoDataLossInDiscreteFourierTransferOf: inputSequence [
 
 	| zeroedRealData f zeroedImaginaryData inputOutputDiff |

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -66,8 +66,8 @@ PMFFTTest >> testThatDiscreteFourierTransformDoesNotLoseDataForLargeDataSets [
 	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
 	inputOutputDiff := f realData - inputSequence.
 	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]) size.
-	self assert: zeroedImaginaryData equals: 256.
-	self assert: zeroedRealData equals: 256.
+	self assert: zeroedImaginaryData equals: inputSequence size.
+	self assert: zeroedRealData equals: inputSequence size.
 
 	PMMitchellMooreGenerator reset: 1
 ]
@@ -85,6 +85,6 @@ PMFFTTest >> testThatDiscreteFourierTransformDoesNotLoseDataForSmallDataSets [
 	zeroedImaginaryData := (f imaginaryData select: [ :i | i equalsTo: 0 ]) size.
 	inputOutputDiff := f realData - inputSequence.
 	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]) size.
-	self assert: zeroedImaginaryData equals: 8.
-	self assert: zeroedRealData equals: 8
+	self assert: zeroedImaginaryData equals: inputSequence size.
+	self assert: zeroedRealData equals: inputSequence size
 ]

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -68,8 +68,7 @@ PMFFTTest >> testThatDiscreteFourierTransformDoesNotLoseDataForLargeDataSets [
 	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]) size.
 	self assert: zeroedImaginaryData equals: inputSequence size.
 	self assert: zeroedRealData equals: inputSequence size.
-
-	PMMitchellMooreGenerator reset: 1
+	
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
+++ b/src/Math-Tests-FastFourierTransform/PMFFTTest.class.st
@@ -85,5 +85,5 @@ PMFFTTest >> testThatDiscreteFourierTransformDoesNotLoseDataForSmallDataSets [
 	inputOutputDiff := f realData - inputSequence.
 	zeroedRealData := (inputOutputDiff select: [ :i | i equalsTo: 0 ]).
 	self assert: zeroedImaginaryData size equals: inputSequence size.
-	self assert: zeroedRealData size equals: inputSequence size
+	self assert: zeroedRealData size equals: inputSequence size.
 ]


### PR DESCRIPTION
Extracting duplicate to a method felt like the most conservative step forward and is an appeal to Kent Beck's Four Rules of Simple Design.

Naming the assertion is proving difficult and so it may be preferable to keep the duplication.