### PR TITLE
Refactor complex number tests: Categorised the test and added other interesting test cases

### DIFF
--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -163,12 +163,7 @@ PMComplexTest >> testArcTanDenominator [
 ]
 
 { #category : #'testing - polar coordinates' }
-PMComplexTest >> testArgumentOfAPositiveRealNumber [
-	self assert: (5 + 0 i) arg equals: 0.
-]
-
-{ #category : #'testing - polar coordinates' }
-PMComplexTest >> testArgumentOfPureImaginaryNumber [
+PMComplexTest >> testArgumentOfAPositivePureImaginaryNumber [
 	"self run: #testArg"
 
 	"self debug: #testArg"
@@ -176,6 +171,11 @@ PMComplexTest >> testArgumentOfPureImaginaryNumber [
 	| c |
 	c := 0 + 5 i.
 	self assert: c arg equals: Float pi / 2
+]
+
+{ #category : #'testing - polar coordinates' }
+PMComplexTest >> testArgumentOfAPositiveRealNumber [
+	self assert: (5 + 0 i) arg equals: 0.
 ]
 
 { #category : #'testing - polar coordinates' }

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -173,6 +173,11 @@ PMComplexTest >> testArgOfPureImaginaryNumber [
 	self assert: c arg equals: Float pi / 2
 ]
 
+{ #category : #'testing - polar coordinates' }
+PMComplexTest >> testArgumentOfAPositiveRealNumber [
+	self assert: (5 + 0 i) arg equals: 0.
+]
+
 { #category : #'testing - bugs' }
 PMComplexTest >> testBug1 [
 	self assert: (0.5 * (2 + 0 i) ln) exp equals: (0.5 * 2 ln) exp

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -163,7 +163,12 @@ PMComplexTest >> testArcTanDenominator [
 ]
 
 { #category : #'testing - polar coordinates' }
-PMComplexTest >> testArgOfPureImaginaryNumber [
+PMComplexTest >> testArgumentOfAPositiveRealNumber [
+	self assert: (5 + 0 i) arg equals: 0.
+]
+
+{ #category : #'testing - polar coordinates' }
+PMComplexTest >> testArgumentOfPureImaginaryNumber [
 	"self run: #testArg"
 
 	"self debug: #testArg"
@@ -171,11 +176,6 @@ PMComplexTest >> testArgOfPureImaginaryNumber [
 	| c |
 	c := 0 + 5 i.
 	self assert: c arg equals: Float pi / 2
-]
-
-{ #category : #'testing - polar coordinates' }
-PMComplexTest >> testArgumentOfAPositiveRealNumber [
-	self assert: (5 + 0 i) arg equals: 0.
 ]
 
 { #category : #'testing - bugs' }

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -162,8 +162,8 @@ PMComplexTest >> testArcTanDenominator [
 	self assert: (c2 arcTan: c1 * c1) equals: Float pi
 ]
 
-{ #category : #tests }
-PMComplexTest >> testArg [
+{ #category : #'testing - polar coordinates' }
+PMComplexTest >> testArgOfPureImaginaryNumber [
 	"self run: #testArg"
 
 	"self debug: #testArg"

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -178,6 +178,11 @@ PMComplexTest >> testArgumentOfPureImaginaryNumber [
 	self assert: c arg equals: Float pi / 2
 ]
 
+{ #category : #'testing - polar coordinates' }
+PMComplexTest >> testArgumentOfPureNegativeImaginaryNumber [
+	self assert: -1 i arg equals: (Float pi / 2) negated
+]
+
 { #category : #'testing - bugs' }
 PMComplexTest >> testBug1 [
 	self assert: (0.5 * (2 + 0 i) ln) exp equals: (0.5 * 2 ln) exp

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -163,6 +163,14 @@ PMComplexTest >> testArcTanDenominator [
 ]
 
 { #category : #'testing - polar coordinates' }
+PMComplexTest >> testArgumentOfAComplexNumber [
+	| z |
+	z := (Fraction numerator: 1 denominator: 2 sqrt) + (Fraction numerator: 1 denominator: 2 sqrt) i.
+	
+	self assert: z arg equals: Float pi / 4
+]
+
+{ #category : #'testing - polar coordinates' }
 PMComplexTest >> testArgumentOfAPositivePureImaginaryNumber [
 	"self run: #testArg"
 

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -164,10 +164,7 @@ PMComplexTest >> testArcTanDenominator [
 
 { #category : #'testing - polar coordinates' }
 PMComplexTest >> testArgumentOfAComplexNumber [
-	| z |
-	z := (Fraction numerator: 1 denominator: 2 sqrt) + (Fraction numerator: 1 denominator: 2 sqrt) i.
-	
-	self assert: z arg equals: Float pi / 4
+	self assert: (1 + 1 i) arg equals: Float pi / 4
 ]
 
 { #category : #'testing - polar coordinates' }


### PR DESCRIPTION
- Added a category which emphasises that complex numbers have a polar coordinate form; 

- added missing tests that felt interesting enough to confirm:
--argument of a real number is 0 radians
-- argument of a negative pure imaginary number is - Pi /2 (I was expecting 3 Pi / 2)