### PR TITLE
Track the test coverage for the Fast Fourier Transform package.

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -14,6 +14,7 @@ SmalltalkCISpec {
 	'Math-C*',
 	'Math-D*',
 	'Math-FunctionFit',
+  'Math-FastFourierTransform',
 	'Math-K*',
 	'Math-M*',
 	'Math-N*',


### PR DESCRIPTION
Use Coveralls.io to track the coverage of the Fast Fourier transform package.