### PR TITLE
Refactor complex number tests: Grouped all arithmetic tests into a clearly named category, added missing interesting test

### DIFF
--- a/src/Math-Complex/PMComplex.class.st
+++ b/src/Math-Complex/PMComplex.class.st
@@ -390,7 +390,7 @@ PMComplex >> arcTan: denominator [
 			res]
 ]
 
-{ #category : #arithmetic }
+{ #category : #'polar coordinates' }
 PMComplex >> arg [
 	"Answer the argument of the receiver."
 

--- a/src/Math-Complex/PMComplex.extension.st
+++ b/src/Math-Complex/PMComplex.extension.st
@@ -18,17 +18,17 @@ PMComplex >> productWithVector: aVector [
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex >> random [
-	"analog to Number>>random. However, the only bound is that the abs of the produced complex is less than the length of the receive. The receiver effectively defines a disc within which the random element can be produced."
-	^ self class random * self
-	
-]
-
-{ #category : #'*Math-Complex' }
 PMComplex class >> random [
 		"Answers a random number with abs between 0 and 1." 
 
 	^ self abs: 1.0 random arg: 2 * Float pi random
+]
+
+{ #category : #'*Math-Complex' }
+PMComplex >> random [
+	"analog to Number>>random. However, the only bound is that the abs of the produced complex is less than the length of the receive. The receiver effectively defines a disc within which the random element can be produced."
+	^ self class random * self
+	
 ]
 
 { #category : #'*Math-Complex' }

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -46,7 +46,7 @@ PMComplexTest >> testAdaptToCollectionAndSend [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testAddPolynomial [
+PMComplexTest >> testAddingToAPolynomial [
 	| c poly |
 	c := 6 - 6 i.
 	poly := PMPolynomial coefficients: #(1 1 1).
@@ -55,7 +55,7 @@ PMComplexTest >> testAddPolynomial [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testAdding [
+PMComplexTest >> testAddingTwoComplexNumbers [
 	"self run: #testAdding"
 
 	| c |
@@ -309,15 +309,7 @@ PMComplexTest >> testCreation [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testDividingPolynomial [
-	| c poly |
-	c := 4 + 4 i.
-	poly := PMPolynomial coefficients: #(1 0 1).
-	self assert: poly / c equals: 1 / c * poly
-]
-
-{ #category : #'testing - arithmetic' }
-PMComplexTest >> testDivision1 [
+PMComplexTest >> testDividingALargeComplexNumbersByItself [
 	"self run: #testDivision1"
 	"self debug: #testDivision1"
 	
@@ -332,6 +324,14 @@ PMComplexTest >> testDivision1 [
 	how this can be avoided."
 	
 
+]
+
+{ #category : #'testing - arithmetic' }
+PMComplexTest >> testDividingPolynomialByAComplexNumber [
+	| c poly |
+	c := 4 + 4 i.
+	poly := PMPolynomial coefficients: #(1 0 1).
+	self assert: poly / c equals: 1 / c * poly
 ]
 
 { #category : #'testing - equality' }
@@ -451,6 +451,15 @@ PMComplexTest >> testMultiplyByI [
 	| c |
 	c := 5 - 6 i.
 	self assert: c * 1 i equals: c i
+]
+
+{ #category : #'testing - arithmetic' }
+PMComplexTest >> testMultiplyingByPolynomials [
+	| c poly |
+	c := 1 + 1 i.
+	poly := PMPolynomial coefficients: #(1).
+	self assert: (c * poly at: 0) equals: c.
+	self assert: (poly * c at: 0) equals: c
 ]
 
 { #category : #'testing - arithmetic' }
@@ -707,7 +716,7 @@ PMComplexTest >> testSquared [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testSubtractToPolynomial [
+PMComplexTest >> testSubtractingPolynomials [
 	| c poly |
 	poly := PMPolynomial coefficients: #(1 2 3).
 	c := 1 + 3 i.
@@ -737,15 +746,6 @@ PMComplexTest >> testTanh [
 	c2 := c sinh / c cosh.
 	self assert: (c2 real closeTo: c tanh real).
 	self assert: (c2 imaginary closeTo: c tanh imaginary).
-]
-
-{ #category : #'testing - arithmetic' }
-PMComplexTest >> testTimesPolynomial [
-	| c poly |
-	c := 1 + 1 i.
-	poly := PMPolynomial coefficients: #(1).
-	self assert: (c * poly at: 0) equals: c.
-	self assert: (poly * c at: 0) equals: c
 ]
 
 { #category : #'testing - equality' }

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -775,6 +775,11 @@ PMComplexTest >> testWeCanWriteComplexNumbersWhoseRealAndImaginaryPartsAreFracti
 	self assert: (z imaginary) equals: (Fraction numerator: 4 denominator: 5).
 ]
 
+{ #category : #'testing - arithmetic' }
+PMComplexTest >> testWeCannotTakeReciprocalOfZeroComplexNumbers [
+	self should: [ PMComplex zero reciprocal ] raise: ZeroDivide.
+]
+
 { #category : #'testing - expressing complex numbers' }
 PMComplexTest >> testWeCannotWriteFractionsOfComplexNumbersWithDenominatorNormalized [
 

--- a/src/Math-Tests-Complex/PMComplexTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexTest.class.st
@@ -45,7 +45,7 @@ PMComplexTest >> testAdaptToCollectionAndSend [
 	self assert: (arr * c at: 2) equals: c
 ]
 
-{ #category : #tests }
+{ #category : #'testing - arithmetic' }
 PMComplexTest >> testAddPolynomial [
 	| c poly |
 	c := 6 - 6 i.
@@ -54,7 +54,7 @@ PMComplexTest >> testAddPolynomial [
 	self assert: (c + poly at: 0) equals: 7 - 6 i
 ]
 
-{ #category : #tests }
+{ #category : #'testing - arithmetic' }
 PMComplexTest >> testAdding [
 	"self run: #testAdding"
 
@@ -214,7 +214,7 @@ PMComplexTest >> testComplexCollection [
 		do: [ :one :two | self assert: 2 * one equals: two ]
 ]
 
-{ #category : #tests }
+{ #category : #'testing - arithmetic' }
 PMComplexTest >> testComplexConjugate [
 
 	self assert: (5 - 6i) complexConjugate equals: (5 + 6i).
@@ -308,7 +308,7 @@ PMComplexTest >> testCreation [
 	self assert: c imaginary equals: 5
 ]
 
-{ #category : #tests }
+{ #category : #'testing - arithmetic' }
 PMComplexTest >> testDividingPolynomial [
 	| c poly |
 	c := 4 + 4 i.
@@ -316,7 +316,7 @@ PMComplexTest >> testDividingPolynomial [
 	self assert: poly / c equals: 1 / c * poly
 ]
 
-{ #category : #tests }
+{ #category : #'testing - arithmetic' }
 PMComplexTest >> testDivision1 [
 	"self run: #testDivision1"
 	"self debug: #testDivision1"
@@ -446,14 +446,14 @@ PMComplexTest >> testLog [
 	self assert: (2 + 0 i log: 2) equals: 1
 ]
 
-{ #category : #tests }
+{ #category : #'testing - arithmetic' }
 PMComplexTest >> testMultiplyByI [
 	| c |
 	c := 5 - 6 i.
 	self assert: c * 1 i equals: c i
 ]
 
-{ #category : #tests }
+{ #category : #'testing - arithmetic' }
 PMComplexTest >> testNegated [
 	"self run: #testNegated"
 
@@ -537,7 +537,7 @@ PMComplexTest >> testRandom [
 	self assert: r abs < c abs
 ]
 
-{ #category : #tests }
+{ #category : #'testing - arithmetic' }
 PMComplexTest >> testReciprocal [
 	"self run: #testReciprocal"
 
@@ -559,7 +559,7 @@ PMComplexTest >> testReciprocalError [
 	
 ]
 
-{ #category : #tests }
+{ #category : #'testing - arithmetic' }
 PMComplexTest >> testSecureDivision1 [
 	"self run: #testSecureDivision1"
 	"self debug: #testSecureDivision1"
@@ -572,7 +572,7 @@ PMComplexTest >> testSecureDivision1 [
 	
 ]
 
-{ #category : #tests }
+{ #category : #'testing - arithmetic' }
 PMComplexTest >> testSecureDivision2 [
 	"self run: #testSecureDivision2"
 	"self debug: #testSecureDivision2"
@@ -706,7 +706,7 @@ PMComplexTest >> testSquared [
 	self assert: c2 real equals: 0
 ]
 
-{ #category : #tests }
+{ #category : #'testing - arithmetic' }
 PMComplexTest >> testSubtractToPolynomial [
 	| c poly |
 	poly := PMPolynomial coefficients: #(1 2 3).
@@ -739,7 +739,7 @@ PMComplexTest >> testTanh [
 	self assert: (c2 imaginary closeTo: c tanh imaginary).
 ]
 
-{ #category : #tests }
+{ #category : #'testing - arithmetic' }
 PMComplexTest >> testTimesPolynomial [
 	| c poly |
 	c := 1 + 1 i.


### PR DESCRIPTION
- Categorised the tests that exercise the arithmetic of complex numbers;
- renamed some tests to be a little clearer (inspired by Kevlin Henney's [Structure and Interpretation of Test Cases](https://youtu.be/tWn8RA_DEic))
- added what may be a missing test to demonstrate we cannot take the reciprocal of 0 + 0 i