### PR TITLE
Breaking Change: Renamed the class to follow the ubiquitous language.

### DIFF
--- a/src/Math-Complex/Number.extension.st
+++ b/src/Math-Complex/Number.extension.st
@@ -10,7 +10,7 @@ Number >> adaptToComplex: rcvr andSend: selector [
 Number >> asComplex [
 	"Answer a Complex number that represents value of the receiver."
 
-	^ PMComplex real: self imaginary: 0
+	^ PMComplexNumber real: self imaginary: 0
 ]
 
 { #category : #'*Math-Complex' }
@@ -25,7 +25,7 @@ Number >> complexConjugate [
 
 { #category : #'*Math-Complex' }
 Number >> i [
-	^ PMComplex real: 0 imaginary: self
+	^ PMComplexNumber real: 0 imaginary: self
 ]
 
 { #category : #'*Math-Complex' }
@@ -36,7 +36,7 @@ Number >> i: aNumber [
 	this is the same as (self + aNumber i) but a little bit more efficient."
 
 	aNumber isNumber ifFalse: [self error: 'Badly formed complex number'].
-	^PMComplex real: self imaginary: aNumber
+	^PMComplexNumber real: self imaginary: aNumber
 ]
 
 { #category : #'*Math-Complex' }

--- a/src/Math-Complex/PMComplexNumber.class.st
+++ b/src/Math-Complex/PMComplexNumber.class.st
@@ -84,10 +84,10 @@ Class {
 }
 
 { #category : #'instance creation' }
-PMComplexNumber class >> abs: aNumber1 arg: aNumber2 [
+PMComplexNumber class >> abs: modulus arg: theta [
 	^self
-		real: aNumber1 * aNumber2 cos
-		imaginary: aNumber1 * aNumber2 sin
+		real: modulus * theta cos
+		imaginary: modulus * theta sin
 ]
 
 { #category : #'instance creation' }

--- a/src/Math-Complex/PMComplexNumber.class.st
+++ b/src/Math-Complex/PMComplexNumber.class.st
@@ -74,7 +74,7 @@ Missing methods
 	Complex | mathematical functions | arcTan
 "
 Class {
-	#name : #PMComplex,
+	#name : #PMComplexNumber,
 	#superclass : #Object,
 	#instVars : [
 		'real',
@@ -84,24 +84,24 @@ Class {
 }
 
 { #category : #'instance creation' }
-PMComplex class >> abs: aNumber1 arg: aNumber2 [
+PMComplexNumber class >> abs: aNumber1 arg: aNumber2 [
 	^self
 		real: aNumber1 * aNumber2 cos
 		imaginary: aNumber1 * aNumber2 sin
 ]
 
 { #category : #'instance creation' }
-PMComplex class >> new [
+PMComplexNumber class >> new [
 	^ self real: 0 imaginary: 0
 ]
 
 { #category : #'instance creation' }
-PMComplex class >> one [
+PMComplexNumber class >> one [
 	^ self real: 1 imaginary: 0
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex class >> random [
+PMComplexNumber class >> random [
 	"Answers a random number with abs between 0 and 1." 
 	| random |
 	random := Random new.
@@ -112,17 +112,17 @@ PMComplex class >> random [
 ]
 
 { #category : #'instance creation' }
-PMComplex class >> real: aNumber1 imaginary: aNumber2 [
+PMComplexNumber class >> real: aNumber1 imaginary: aNumber2 [
 	^self basicNew	real: aNumber1 imaginary: aNumber2
 ]
 
 { #category : #'instance creation' }
-PMComplex class >> zero [
+PMComplexNumber class >> zero [
 	^ self real: 0 imaginary: 0
 ]
 
 { #category : #arithmetic }
-PMComplex >> * anObject [
+PMComplexNumber >> * anObject [
 	"Answer the result of multiplying the receiver by aNumber."
 	| a b c d newReal newImaginary |
 	anObject isComplexNumber
@@ -133,13 +133,13 @@ PMComplex >> * anObject [
 			d := anObject imaginary.
 			newReal := (a * c) - (b * d).
 			newImaginary := (a * d) + (b * c).
-			^ PMComplex real: newReal imaginary: newImaginary]
+			^ PMComplexNumber real: newReal imaginary: newImaginary]
 		ifFalse:
 			[^ anObject adaptToComplex: self andSend: #*]
 ]
 
 { #category : #arithmetic }
-PMComplex >> + anObject [
+PMComplexNumber >> + anObject [
 	"Answer the sum of the receiver and aNumber."
 	| a b c d newReal newImaginary |
 	anObject isComplexNumber
@@ -150,13 +150,13 @@ PMComplex >> + anObject [
 			d := anObject imaginary.
 			newReal := a + c.
 			newImaginary := b + d.
-			^ PMComplex real: newReal imaginary: newImaginary]
+			^ PMComplexNumber real: newReal imaginary: newImaginary]
 		ifFalse:
 			[^ anObject adaptToComplex: self andSend: #+]
 ]
 
 { #category : #arithmetic }
-PMComplex >> - anObject [
+PMComplexNumber >> - anObject [
 	"Answer the difference between the receiver and aNumber."
 	| a b c d newReal newImaginary |
 	anObject isComplexNumber
@@ -167,13 +167,13 @@ PMComplex >> - anObject [
 			d := anObject imaginary.
 			newReal := a - c.
 			newImaginary := b - d.
-			^ PMComplex real: newReal imaginary: newImaginary]
+			^ PMComplexNumber real: newReal imaginary: newImaginary]
 		ifFalse:
 			[^ anObject adaptToComplex: self andSend: #-]
 ]
 
 { #category : #arithmetic }
-PMComplex >> / aNumber [
+PMComplexNumber >> / aNumber [
 	"Answer the result of dividing receiver by aNumber"
 	| a b c d newReal newImaginary |
 	aNumber isComplexNumber ifTrue:
@@ -188,7 +188,7 @@ PMComplex >> / aNumber [
 ]
 
 { #category : #comparing }
-PMComplex >> = anObject [
+PMComplexNumber >> = anObject [
 	anObject isNumber ifFalse: [^false].
 	anObject isComplexNumber
 		ifTrue: [^ (real = anObject real) & (imaginary = anObject imaginary)]
@@ -196,14 +196,14 @@ PMComplex >> = anObject [
 ]
 
 { #category : #arithmetic }
-PMComplex >> abs [
+PMComplexNumber >> abs [
 	"Answer the distance of the receiver from zero (0 + 0 i)."
 
 	^ ((real * real) + (imaginary * imaginary)) sqrt
 ]
 
 { #category : #arithmetic }
-PMComplex >> absSecure [
+PMComplexNumber >> absSecure [
 	"Answer the distance of the receiver from zero (0 + 0 i).
 	Try avoiding overflow and/or underflow"
 
@@ -215,13 +215,13 @@ PMComplex >> absSecure [
 ]
 
 { #category : #arithmetic }
-PMComplex >> absSquared [
+PMComplexNumber >> absSquared [
 
 	^ self real * self real + (self imaginary * self imaginary)
 ]
 
 { #category : #converting }
-PMComplex >> adaptToCollection: rcvr andSend: selector [
+PMComplexNumber >> adaptToCollection: rcvr andSend: selector [
 	"If I am involved in arithmetic with a Collection, return a Collection of
 	the results of each element combined with me in that expression."
 
@@ -229,30 +229,30 @@ PMComplex >> adaptToCollection: rcvr andSend: selector [
 ]
 
 { #category : #converting }
-PMComplex >> adaptToFloat: rcvr andSend: selector [
+PMComplexNumber >> adaptToFloat: rcvr andSend: selector [
 	"If I am involved in arithmetic with a Float, convert it to a Complex number."
 	^ rcvr asComplex perform: selector with: self
 ]
 
 { #category : #converting }
-PMComplex >> adaptToFraction: rcvr andSend: selector [
+PMComplexNumber >> adaptToFraction: rcvr andSend: selector [
 	"If I am involved in arithmetic with a Fraction, convert it to a Complex number."
 	^ rcvr asComplex perform: selector with: self
 ]
 
 { #category : #converting }
-PMComplex >> adaptToInteger: rcvr andSend: selector [
+PMComplexNumber >> adaptToInteger: rcvr andSend: selector [
 	"If I am involved in arithmetic with an Integer, convert it to a Complex number."
 	^ rcvr asComplex perform: selector with: self
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex >> addPolynomial: aPolynomial [
+PMComplexNumber >> addPolynomial: aPolynomial [
 	^ aPolynomial addNumber: self
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> arCosh [
+PMComplexNumber >> arCosh [
 	"Answer receiver's area hyperbolic cosine.
 	That is the inverse function of cosh.
 	Some possible implementations:
@@ -284,7 +284,7 @@ PMComplex >> arCosh [
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> arSinh [
+PMComplexNumber >> arSinh [
 	"Answer receiver's area hyperbolic sine.
 	That is the inverse function of sinh."
 
@@ -298,7 +298,7 @@ PMComplex >> arSinh [
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> arTanh [
+PMComplexNumber >> arTanh [
 	"Answer receiver's area hyperbolic tangent.
 	That is the inverse function of tanh."
 
@@ -310,7 +310,7 @@ PMComplex >> arTanh [
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> arcCos [
+PMComplexNumber >> arcCos [
 	"Answer the arc cosine of the receiver.
 	This is the inverse function of cos."
 
@@ -335,7 +335,7 @@ PMComplex >> arcCos [
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> arcSin [
+PMComplexNumber >> arcSin [
 	"Answer the arc sine of the receiver.
 	This is the inverse function of sin."
 
@@ -360,7 +360,7 @@ PMComplex >> arcSin [
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> arcTan [
+PMComplexNumber >> arcTan [
 	"Answer the arc tangent of the receiver.
 	This is the inverse function of tan."
 
@@ -372,7 +372,7 @@ PMComplex >> arcTan [
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> arcTan: denominator [ 
+PMComplexNumber >> arcTan: denominator [ 
 	"Answer the  four quadrants arc tangent of receiver over denominator."
 
 	^denominator isZero 
@@ -395,7 +395,7 @@ PMComplex >> arcTan: denominator [
 ]
 
 { #category : #'polar coordinates' }
-PMComplex >> arg [
+PMComplexNumber >> arg [
 	"Answer the argument of the receiver."
 
 	self isZero ifTrue: [self error: 'zero has no argument.'].
@@ -403,12 +403,12 @@ PMComplex >> arg [
 ]
 
 { #category : #converting }
-PMComplex >> asComplex [
+PMComplexNumber >> asComplex [
 	^self
 ]
 
 { #category : #comparing }
-PMComplex >> closeTo: aNumber precision: aPrecision [
+PMComplexNumber >> closeTo: aNumber precision: aPrecision [
 	"A complex number self is close to a complex number other with precision epsilon if both
 	self real is close to other real with precision epsilon and
 	self imaginary is close to other imaginary with precision epsilon.
@@ -423,13 +423,13 @@ PMComplex >> closeTo: aNumber precision: aPrecision [
 ]
 
 { #category : #arithmetic }
-PMComplex >> complexConjugate [
+PMComplexNumber >> complexConjugate [
 
 	^ self class real: real imaginary: imaginary negated
 ]
 
 { #category : #arithmetic }
-PMComplex >> conjugated [
+PMComplexNumber >> conjugated [
 	"Return the complex conjugate of this complex number."
 
 	self
@@ -442,14 +442,14 @@ PMComplex >> conjugated [
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> cos [
+PMComplexNumber >> cos [
 	"Answer receiver's cosine."
 
 	^self i cosh
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> cosh [
+PMComplexNumber >> cosh [
 	"Answer receiver's hyperbolic cosine.
 	Hyperbolic cosine is defined by same power serie expansion as for real numbers, that is in term of exponential:
 	^ (self exp + self negated exp) / 2.
@@ -461,7 +461,7 @@ PMComplex >> cosh [
 ]
 
 { #category : #arithmetic }
-PMComplex >> divideFastAndSecureBy: anObject [
+PMComplexNumber >> divideFastAndSecureBy: anObject [
 	"Answer the result of dividing receiver by aNumber"
 	" Both operands are scaled to avoid arithmetic overflow. 
 	  This algorithm works for a wide range of values, and it needs only three divisions.
@@ -483,12 +483,12 @@ PMComplex >> divideFastAndSecureBy: anObject [
 			newImaginary := r*imaginary - real/d.
 		    ].
 		
-		^ PMComplex real: newReal imaginary: newImaginary].
+		^ PMComplexNumber real: newReal imaginary: newImaginary].
 	^ anObject adaptToComplex: self andSend: #/.
 ]
 
 { #category : #arithmetic }
-PMComplex >> divideSecureBy: anObject [
+PMComplexNumber >> divideSecureBy: anObject [
 	"Answer the result of dividing receiver by aNumber"
 	" Both operands are scaled to avoid arithmetic overflow. This algorithm 
 	  works for a wide range of values, but it requires six divisions.  
@@ -506,24 +506,24 @@ PMComplex >> divideSecureBy: anObject [
 		
 		newReal := ars*brs + (ais*bis) /s.
 		newImaginary := ais*brs - (ars*bis)/s.
-		^ PMComplex real: newReal imaginary: newImaginary].
+		^ PMComplexNumber real: newReal imaginary: newImaginary].
 	^ anObject adaptToComplex: self andSend: #/.
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex >> dividingPolynomial: aPolynomial [
+PMComplexNumber >> dividingPolynomial: aPolynomial [
 	^ aPolynomial timesNumber: 1 / self
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> exp [
+PMComplexNumber >> exp [
 	"Answer the exponential of the receiver."
 
 	^ real exp * (imaginary cos + imaginary sin i)
 ]
 
 { #category : #private }
-PMComplex >> floatClass [
+PMComplexNumber >> floatClass [
 	"Answer the class suitable for doing floating point operations.
 	In default Squeak, this is Float.
 	In an image with single and double IEEE 754 floating point numbers,
@@ -533,14 +533,14 @@ PMComplex >> floatClass [
 ]
 
 { #category : #comparing }
-PMComplex >> hash [
+PMComplexNumber >> hash [
 	"Hash is reimplemented because = is implemented."
 	
 	^ real hash bitXor: imaginary hash.
 ]
 
 { #category : #arithmetic }
-PMComplex >> i [
+PMComplexNumber >> i [
 	"Answer the result of multiplying the receiver with pure imaginary.
 		^self * 1 i
 	This is an obvious extension of method i implemented in Number."
@@ -549,12 +549,12 @@ PMComplex >> i [
 ]
 
 { #category : #accessing }
-PMComplex >> imaginary [
+PMComplexNumber >> imaginary [
 	^ imaginary
 ]
 
 { #category : #testing }
-PMComplex >> isComplexConjugateOf: aNumber [
+PMComplexNumber >> isComplexConjugateOf: aNumber [
 	"Answer true if self and aNumber are complex conjugates of each other. The complex conjugate of a complex number is the number with an equal real part and an imaginary part equal in magnitude but opposite in sign."
 	self
 		deprecated: 'This method is redundant. Just check the equality with complexConjugate'
@@ -564,43 +564,43 @@ PMComplex >> isComplexConjugateOf: aNumber [
 ]
 
 { #category : #testing }
-PMComplex >> isComplexNumber [
+PMComplexNumber >> isComplexNumber [
 	^ true
 ]
 
 { #category : #testing }
-PMComplex >> isNumber [
+PMComplexNumber >> isNumber [
 	^ true
 ]
 
 { #category : #testing }
-PMComplex >> isZero [
+PMComplexNumber >> isZero [
 	^ real isZero and: [imaginary isZero]
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> ln [
+PMComplexNumber >> ln [
 	"Answer the natural log of the receiver."
 
 	^ self abs ln + self arg i
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> log: aNumber [ 
+PMComplexNumber >> log: aNumber [ 
 	"Answer the log base aNumber of the receiver."
 
 	^self ln / aNumber ln
 ]
 
 { #category : #arithmetic }
-PMComplex >> negated [
+PMComplexNumber >> negated [
 	"Answer a Number that is the negation of the receiver."
 
 	^self class real: real negated imaginary: imaginary negated
 ]
 
 { #category : #printing }
-PMComplex >> printOn: aStream [
+PMComplexNumber >> printOn: aStream [
 	real printOn: aStream.
 	aStream nextPut: Character space.
 	0 <= imaginary
@@ -614,14 +614,14 @@ PMComplex >> printOn: aStream [
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex >> productWithVector: aVector [
+PMComplexNumber >> productWithVector: aVector [
 	"Answers a new vector product of the receiver with aVector."
 
 	^ aVector collect: [ :each | each * self ]
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> raisedTo: aNumber [ 
+PMComplexNumber >> raisedTo: aNumber [ 
 	"Answer the receiver raised to aNumber."
 
 	aNumber isInteger ifTrue:
@@ -638,7 +638,7 @@ PMComplex >> raisedTo: aNumber [
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> raisedToInteger: operand [ 
+PMComplexNumber >> raisedToInteger: operand [ 
 	"Answer the receiver raised to the power operand, an Integer."
 
 	"implementation note: this code is copied from Number.
@@ -663,26 +663,26 @@ PMComplex >> raisedToInteger: operand [
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex >> random [
+PMComplexNumber >> random [
 	"analog to Number>>random. However, the only bound is that the abs of the produced complex is less than the length of the receive. The receiver effectively defines a disc within which the random element can be produced."
 	^ self class random * self
 	
 ]
 
 { #category : #accessing }
-PMComplex >> real [
+PMComplexNumber >> real [
 	^ real
 ]
 
 { #category : #private }
-PMComplex >> real: aNumber1 imaginary: aNumber2 [
+PMComplexNumber >> real: aNumber1 imaginary: aNumber2 [
 	"Private - initialize the real and imaginary parts of a Complex"
 	real := aNumber1.
 	imaginary := aNumber2.
 ]
 
 { #category : #arithmetic }
-PMComplex >> reciprocal [
+PMComplexNumber >> reciprocal [
 	"Answer 1 divided by the receiver. Create an error notification if the 
 	receiver is 0."
 
@@ -693,24 +693,24 @@ PMComplex >> reciprocal [
 ]
 
 { #category : #testing }
-PMComplex >> sign [
+PMComplexNumber >> sign [
 	^ real sign
 ]
 
 { #category : #testing }
-PMComplex >> signBit [
+PMComplexNumber >> signBit [
 ^self real signBit
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> sin [
+PMComplexNumber >> sin [
 	"Answer receiver's sine."
 
 	^self i sinh i negated
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> sinh [
+PMComplexNumber >> sinh [
 	"Answer receiver's hyperbolic sine.
 	Hyperbolic sine is defined by same power serie expansion as for real numbers, that is in term of exponential:
 	^ (self exp - self negated exp) / 2.
@@ -722,7 +722,7 @@ PMComplex >> sinh [
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> sqrt [
+PMComplexNumber >> sqrt [
 	"Return the square root of the receiver with a positive imaginary part.
 	Implementation based on: https://en.wikipedia.org/wiki/Complex_number#Square_root"
 
@@ -738,33 +738,33 @@ PMComplex >> sqrt [
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> squared [
+PMComplexNumber >> squared [
 	"Answer the receiver multipled by itself."
 
 	^self * self
 ]
 
 { #category : #arithmetic }
-PMComplex >> squaredNorm [
+PMComplexNumber >> squaredNorm [
 	"Answer the square of receiver norm."
 
 	^real * real + (imaginary * imaginary)
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex >> subtractToPolynomial: aPolynomial [
+PMComplexNumber >> subtractToPolynomial: aPolynomial [
 	^ aPolynomial addNumber: self negated
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> tan [
+PMComplexNumber >> tan [
 	"Answer receivers tangent."
 
 	^ self sin / self cos
 ]
 
 { #category : #'mathematical functions' }
-PMComplex >> tanh [
+PMComplexNumber >> tanh [
 	"Answer receiver's hyperbolic tangent."
 
 	"Some possible implementation are:
@@ -780,6 +780,6 @@ PMComplex >> tanh [
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex >> timesPolynomial: aPolynomial [
+PMComplexNumber >> timesPolynomial: aPolynomial [
 	^ aPolynomial timesNumber: self
 ]

--- a/src/Math-Complex/PMComplexNumber.extension.st
+++ b/src/Math-Complex/PMComplexNumber.extension.st
@@ -1,31 +1,31 @@
-Extension { #name : #PMComplex }
+Extension { #name : #PMComplexNumber }
 
 { #category : #'*Math-Complex' }
-PMComplex >> addPolynomial: aPolynomial [
+PMComplexNumber >> addPolynomial: aPolynomial [
 	^ aPolynomial addNumber: self
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex >> dividingPolynomial: aPolynomial [
+PMComplexNumber >> dividingPolynomial: aPolynomial [
 	^ aPolynomial timesNumber: 1 / self
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex >> productWithVector: aVector [
+PMComplexNumber >> productWithVector: aVector [
 	"Answers a new vector product of the receiver with aVector."
 
 	^ aVector collect: [ :each | each * self ]
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex >> random [
+PMComplexNumber >> random [
 	"analog to Number>>random. However, the only bound is that the abs of the produced complex is less than the length of the receive. The receiver effectively defines a disc within which the random element can be produced."
 	^ self class random * self
 	
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex class >> random [
+PMComplexNumber class >> random [
 	"Answers a random number with abs between 0 and 1." 
 	| random |
 	random := Random new.
@@ -36,11 +36,11 @@ PMComplex class >> random [
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex >> subtractToPolynomial: aPolynomial [
+PMComplexNumber >> subtractToPolynomial: aPolynomial [
 	^ aPolynomial addNumber: self negated
 ]
 
 { #category : #'*Math-Complex' }
-PMComplex >> timesPolynomial: aPolynomial [
+PMComplexNumber >> timesPolynomial: aPolynomial [
 	^ aPolynomial timesNumber: self
 ]

--- a/src/Math-FastFourierTransform/PMFastFourierTransform.class.st
+++ b/src/Math-FastFourierTransform/PMFastFourierTransform.class.st
@@ -38,7 +38,7 @@ PMFastFourierTransform >> chop: tolerance [
 				ifTrue: [ r := 0 ].
 			i abs < tolerance
 				ifTrue: [ i := 0 ].
-			PMComplex real: r imaginary: i ]
+			PMComplexNumber real: r imaginary: i ]
 ]
 
 { #category : #accessing }
@@ -98,9 +98,9 @@ PMFastFourierTransform >> inverseTransform [
 PMFastFourierTransform >> multiplier: theta [
 	^ theta < (n // 4)
 		ifTrue:
-			[ PMComplex real: (sinTable at: sinTable size - theta) imaginary: (sinTable at: theta + 1) ]
+			[ PMComplexNumber real: (sinTable at: sinTable size - theta) imaginary: (sinTable at: theta + 1) ]
 		ifFalse:
-			[ PMComplex
+			[ PMComplexNumber
 				real: (sinTable at: theta - (n // 4) + 1) negated
 				imaginary: (sinTable at: n // 2 - theta + 1) ]
 ]
@@ -119,7 +119,7 @@ PMFastFourierTransform >> realData [
 PMFastFourierTransform >> scaleData [
 	| temp |
 	temp := n sqrt.
-	data := data collect: [ :j | PMComplex real: j real / temp imaginary: j imaginary / temp ]	"minimizes floating point error this way"
+	data := data collect: [ :j | PMComplexNumber real: j real / temp imaginary: j imaginary / temp ]	"minimizes floating point error this way"
 ]
 
 { #category : #evaluation }

--- a/src/Math-Quaternion/PMComplexNumber.extension.st
+++ b/src/Math-Quaternion/PMComplexNumber.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #PMComplex }
+Extension { #name : #PMComplexNumber }
 
 { #category : #'*Math-Quaternion' }
-PMComplex >> adaptToQuaternion: rcvr andSend: selector [ 
+PMComplexNumber >> adaptToQuaternion: rcvr andSend: selector [ 
 	"If I am involved in arithmetic with a Quaternion, convert me to a Quaternion."
 	^ rcvr perform: selector with: self asQuaternion
 ]
 
 { #category : #'*Math-Quaternion' }
-PMComplex >> asQuaternion [
+PMComplexNumber >> asQuaternion [
 	^ PMQuaternion
 		qr: real
 		qi: imaginary
@@ -16,7 +16,7 @@ PMComplex >> asQuaternion [
 ]
 
 { #category : #'*Math-Quaternion' }
-PMComplex >> j [
+PMComplexNumber >> j [
 	"same as self * 1 j"
 
 	^PMQuaternion 
@@ -27,7 +27,7 @@ PMComplex >> j [
 ]
 
 { #category : #'*Math-Quaternion' }
-PMComplex >> k [
+PMComplexNumber >> k [
 	"same as self * 1 k"
 
 	^PMQuaternion 

--- a/src/Math-Tests-Complex/PMComplexNumberTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexNumberTest.class.st
@@ -503,6 +503,18 @@ PMComplexNumberTest >> testNew [
 	self assert: c imaginary equals: 0
 ]
 
+{ #category : #'testing - expressing complex numbers' }
+PMComplexNumberTest >> testNormalizedFractionsOfComplexNumbersCannotBeWritten [
+
+	| z w numerator denominator |
+	z := 1 + 2 i.
+	w := 3 + 4 i.
+	numerator := z * w complexConjugate.
+	denominator := w squaredNorm.
+	
+	self should: [ Fraction numerator: numerator denominator: w squaredNorm ] raise: Exception.
+]
+
 { #category : #'testing - close to' }
 PMComplexNumberTest >> testNotCloseToRealWithPrecision [
 
@@ -553,6 +565,17 @@ PMComplexNumberTest >> testPureImaginaryNumbersAreNotEqualToObjectsOfADifferentT
 	self deny: nil = 1 i.
 	self deny: 1 i = #(1 2 3).
 	self deny: #(1 2 3) = 1 i.
+]
+
+{ #category : #'testing - expressing complex numbers' }
+PMComplexNumberTest >> testQuotientsOfComplexNumbersCannotBeWritten [
+	| numerator denominator |
+	"It is interesting that we cannot instanciate a fraction of the form z/w"
+	"Perhaps, we could do something like z * (w*)/ |w|**2"
+	numerator := PMComplexNumber real: 1 imaginary: 1.
+	denominator := PMComplexNumber real: 3 imaginary: 4 .
+
+	self should: [ Fraction numerator: numerator denominator: denominator ] raise: Exception .
 ]
 
 { #category : #'testing - mathematical functions' }
@@ -825,35 +848,12 @@ PMComplexNumberTest >> testTwoComplexNumbersWithDifferentRealPartsAreNotEqual [
 ]
 
 { #category : #'testing - expressing complex numbers' }
-PMComplexNumberTest >> testWeCanWriteComplexNumbersWhoseRealAndImaginaryPartsAreFractions [
+PMComplexNumberTest >> testWritingComplexNumbersWhoseRealAndImaginaryPartsAreFractions [
 	| z |
 	z := PMComplexNumber real: 3 / 5 imaginary: 4 / 5.
 	 
 	self assert: (z real) equals: (Fraction numerator: 3 denominator: 5).
 	self assert: (z imaginary) equals: (Fraction numerator: 4 denominator: 5).
-]
-
-{ #category : #'testing - expressing complex numbers' }
-PMComplexNumberTest >> testWeCannotWriteFractionsOfComplexNumbersWithDenominatorNormalized [
-
-	| z w numerator denominator |
-	z := 1 + 2 i.
-	w := 3 + 4 i.
-	numerator := z * w complexConjugate.
-	denominator := w squaredNorm.
-	
-	self should: [ Fraction numerator: numerator denominator: w squaredNorm ] raise: Exception.
-]
-
-{ #category : #'testing - expressing complex numbers' }
-PMComplexNumberTest >> testWeCannotWriteFractionsWhoseNumeratorAndDenominatorAreComplexNumbers [
-	| numerator denominator |
-	"It is interesting that we cannot instanciate a fraction of the form z/w"
-	"Perhaps, we could do something like z * (w*)/ |w|**2"
-	numerator := PMComplexNumber real: 1 imaginary: 1.
-	denominator := PMComplexNumber real: 3 imaginary: 4 .
-
-	self should: [ Fraction numerator: numerator denominator: denominator ] raise: Exception .
 ]
 
 { #category : #'testing - expressing complex numbers' }

--- a/src/Math-Tests-Complex/PMComplexNumberTest.class.st
+++ b/src/Math-Tests-Complex/PMComplexNumberTest.class.st
@@ -1,17 +1,17 @@
 Class {
-	#name : #PMComplexTest,
+	#name : #PMComplexNumberTest,
 	#superclass : #TestCase,
 	#category : #'Math-Tests-Complex'
 }
 
 { #category : #'testing - equality' }
-PMComplexTest >> testAPureImaginaryNumberIsNotEqualToZero [
+PMComplexNumberTest >> testAPureImaginaryNumberIsNotEqualToZero [
 	self deny: 1 i equals: 0.
 	self deny: 0 equals: 1 i.
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testAbs [
+PMComplexNumberTest >> testAbs [
 	"self run: #testAbs"
 
 	"self debug: #testAbs"
@@ -22,7 +22,7 @@ PMComplexTest >> testAbs [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testAbsSecure [
+PMComplexNumberTest >> testAbsSecure [
 
 	"self run: #testAbsSecure"
 
@@ -34,7 +34,7 @@ PMComplexTest >> testAbsSecure [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testAddingComplexNumbersToAnArrayOfIntegers [
+PMComplexNumberTest >> testAddingComplexNumbersToAnArrayOfIntegers [
 	| c arrayOfIntegers expected |
 	c := 6 - 6 i.
 	arrayOfIntegers := #(0 1 2 3 4 5).
@@ -44,25 +44,25 @@ PMComplexTest >> testAddingComplexNumbersToAnArrayOfIntegers [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testAddingFractionsAndComplexNumbers [	
+PMComplexNumberTest >> testAddingFractionsAndComplexNumbers [	
 	self assert: 1 + 2 i + (2 / 3) equals: 5 / 3 + 2 i.
 	self assert: 2 / 3 + (1 + 2 i) equals: 5 / 3 + 2 i
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testAddingIntegersAndComplexNumbers [
+PMComplexNumberTest >> testAddingIntegersAndComplexNumbers [
 	self assert: 1 + 2 i + 1 equals: 2 + 2 i.
 	self assert: 1 + (1 + 2 i) equals: 2 + 2 i.
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testAddingRealNumbersAndComplexNumbers [
+PMComplexNumberTest >> testAddingRealNumbersAndComplexNumbers [
 	self assert: 1 + 2 i + 1.0 equals: 2.0 + 2 i.
 	self assert: 1.0 + (1 + 2 i) equals: 2.0 + 2 i.
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testAddingToAPolynomial [
+PMComplexNumberTest >> testAddingToAPolynomial [
 	| c poly |
 	c := 6 - 6 i.
 	poly := PMPolynomial coefficients: #(1 1 1).
@@ -71,14 +71,14 @@ PMComplexTest >> testAddingToAPolynomial [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testAddingTwoComplexNumbers [
+PMComplexNumberTest >> testAddingTwoComplexNumbers [
 	| c |
 	c := 5 - 6 i + (-5 + 8 i).	"Complex with Complex"
 	self assert: c equals: 0 + 2 i
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testArCosh [
+PMComplexNumberTest >> testArCosh [
 	| c |
 	c := (2.5 + 0 i).
 	self assert: (c arCosh real closeTo: c real arCosh).
@@ -92,7 +92,7 @@ PMComplexTest >> testArCosh [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testArSinh [
+PMComplexNumberTest >> testArSinh [
 	| c |
 	c := (2.5 + 0 i).
 	self assert: (c arSinh real closeTo: c real arSinh).
@@ -105,7 +105,7 @@ PMComplexTest >> testArSinh [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testArTanh [
+PMComplexNumberTest >> testArTanh [
 	| c |
 	c := (0.5 + 0 i).
 	self assert: (c arTanh real closeTo: c real arTanh).
@@ -118,7 +118,7 @@ PMComplexTest >> testArTanh [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testArcCos [
+PMComplexNumberTest >> testArcCos [
 	| c |
 	c := (0.5 + 0 i).
 	self assert: (c arcCos real closeTo: c real arcCos).
@@ -131,7 +131,7 @@ PMComplexTest >> testArcCos [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testArcCosPlusArcSin [
+PMComplexNumberTest >> testArcCosPlusArcSin [
 	| c |
 	#(-0.5 -2 -3 0 0.5 2 3) do: [:real |
 	#(-0.5 -2 -3 0 0.5 2 3) do: [:imag |
@@ -141,7 +141,7 @@ PMComplexTest >> testArcCosPlusArcSin [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testArcSin [
+PMComplexNumberTest >> testArcSin [
 	| c |
 	c := (0.5 + 0 i).
 	self assert: (c arcSin real closeTo: c real arcSin).
@@ -154,7 +154,7 @@ PMComplexTest >> testArcSin [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testArcTan [
+PMComplexNumberTest >> testArcTan [
 	| c |
 	c := (0.5 + 0 i).
 	self assert: (c arcTan real closeTo: c real arcTan).
@@ -167,7 +167,7 @@ PMComplexTest >> testArcTan [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testArcTanDenominator [
+PMComplexNumberTest >> testArcTanDenominator [
 	| c1 c2 |
 	c1 := 1 i.
 	c2 := 0.
@@ -177,34 +177,34 @@ PMComplexTest >> testArcTanDenominator [
 ]
 
 { #category : #'testing - polar coordinates' }
-PMComplexTest >> testArgumentOfAComplexNumber [
+PMComplexNumberTest >> testArgumentOfAComplexNumber [
 	self assert: (1 + 1 i) arg equals: Float pi / 4
 ]
 
 { #category : #'testing - polar coordinates' }
-PMComplexTest >> testArgumentOfAPositivePureImaginaryNumber [
+PMComplexNumberTest >> testArgumentOfAPositivePureImaginaryNumber [
 	| c |
 	c := 0 + 5 i.
 	self assert: c arg equals: Float pi / 2
 ]
 
 { #category : #'testing - polar coordinates' }
-PMComplexTest >> testArgumentOfAPositiveRealNumber [
+PMComplexNumberTest >> testArgumentOfAPositiveRealNumber [
 	self assert: (5 + 0 i) arg equals: 0.
 ]
 
 { #category : #'testing - polar coordinates' }
-PMComplexTest >> testArgumentOfPureNegativeImaginaryNumber [
+PMComplexNumberTest >> testArgumentOfPureNegativeImaginaryNumber [
 	self assert: -1 i arg equals: (Float pi / 2) negated
 ]
 
 { #category : #'testing - bugs' }
-PMComplexTest >> testBug1 [
+PMComplexNumberTest >> testBug1 [
 	self assert: (0.5 * (2 + 0 i) ln) exp equals: (0.5 * 2 ln) exp
 ]
 
 { #category : #'testing - close to' }
-PMComplexTest >> testCloseTo [
+PMComplexNumberTest >> testCloseTo [
 
 	self assert: 2 + 3.000000000000001i closeTo: 2 + 3i.
 	self assert: 2.000000000000001 + 3i closeTo: 2 + 3i.
@@ -212,7 +212,7 @@ PMComplexTest >> testCloseTo [
 ]
 
 { #category : #'testing - close to' }
-PMComplexTest >> testCloseToReal [
+PMComplexNumberTest >> testCloseToReal [
 
 	self assert: 2 + 0.000000000000001i closeTo: 2.
 	self assert: 2.000000000000001 + 0.000000000000001i closeTo: 2.
@@ -222,14 +222,14 @@ PMComplexTest >> testCloseToReal [
 ]
 
 { #category : #'testing - close to' }
-PMComplexTest >> testCloseToRealWithPrecision [
+PMComplexNumberTest >> testCloseToRealWithPrecision [
 
 	self assert: 2 + 0.001i closeTo: 2 precision: 0.01.
 	self assert: 2.001 + 0.001i closeTo: 2 precision: 0.01.
 ]
 
 { #category : #'testing - close to' }
-PMComplexTest >> testCloseToWithPrecision [
+PMComplexNumberTest >> testCloseToWithPrecision [
 
 	self assert: 2 + 3.001i closeTo: 2 + 3i precision: 0.01.
 	self assert: 2.001 + 3i closeTo: 2 + 3i precision: 0.01.
@@ -237,18 +237,18 @@ PMComplexTest >> testCloseToWithPrecision [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testComplexConjugate [
+PMComplexNumberTest >> testComplexConjugate [
 
 	self assert: (5 - 6i) complexConjugate equals: (5 + 6i).
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testComplexNumberAndIntegerAreUnequalEvenIfRealPartIsEqualToInteger [
+PMComplexNumberTest >> testComplexNumberAndIntegerAreUnequalEvenIfRealPartIsEqualToInteger [
 	self deny: 1 + 3 i equals: 1.
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testCos [
+PMComplexNumberTest >> testCos [
 	| c c2 |
 	c := (2 + 0 i).
 	self assert: (c cos real closeTo: c real cos).
@@ -260,7 +260,7 @@ PMComplexTest >> testCos [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testCos2PlusSin2 [
+PMComplexNumberTest >> testCos2PlusSin2 [
 	| c |
 	#(-0.5 -2 -3 0 0.5 2 3) do: [:real |
 	#(-0.5 -2 -3 0 0.5 2 3) do: [:imag |
@@ -270,7 +270,7 @@ PMComplexTest >> testCos2PlusSin2 [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testCosh [
+PMComplexNumberTest >> testCosh [
 	| c c2 |
 	c := (2 + 0 i).
 	self assert: (c cosh real closeTo: c real cosh).
@@ -285,7 +285,7 @@ PMComplexTest >> testCosh [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testCosh2MinusSinh2 [
+PMComplexNumberTest >> testCosh2MinusSinh2 [
 	| c |
 	#(-0.5 -2 -3 0 0.5 2 3) do: [:real |
 	#(-0.5 -2 -3 0 0.5 2 3) do: [:imag |
@@ -295,7 +295,7 @@ PMComplexTest >> testCosh2MinusSinh2 [
 ]
 
 { #category : #'testing - expressing complex numbers' }
-PMComplexTest >> testCreation [
+PMComplexNumberTest >> testCreation [
 	| c |
 	c := 5 i.
 	self assert: c real equals: 0.
@@ -306,16 +306,16 @@ PMComplexTest >> testCreation [
 	c := 5.6 - 8 i.
 	self assert: c real equals: 5.6.
 	self assert: c imaginary equals: -8.
-	c := PMComplex real: 10 imaginary: 5.
+	c := PMComplexNumber real: 10 imaginary: 5.
 	self assert: c real equals: 10.
 	self assert: c imaginary equals: 5.
-	c := PMComplex abs: 5 arg: Float pi / 2.
+	c := PMComplexNumber abs: 5 arg: Float pi / 2.
 	self assert: c real rounded equals: 0.
 	self assert: c imaginary equals: 5
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testDividingALargeComplexNumbersByItself [
+PMComplexNumberTest >> testDividingALargeComplexNumbersByItself [
 	| c1 c2 quotient |
 	c1 := 2.0e252 + 3.0e70 i.
 	c2 := c1.
@@ -330,7 +330,7 @@ PMComplexTest >> testDividingALargeComplexNumbersByItself [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testDividingPolynomialByAComplexNumber [
+PMComplexNumberTest >> testDividingPolynomialByAComplexNumber [
 	| c poly |
 	c := 4 + 4 i.
 	poly := PMPolynomial coefficients: #(1 0 1).
@@ -338,7 +338,7 @@ PMComplexTest >> testDividingPolynomialByAComplexNumber [
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testEqualsIsReflexive [
+PMComplexNumberTest >> testEqualsIsReflexive [
 	| z |
  	z := -10 + 10 i.
 
@@ -346,7 +346,7 @@ PMComplexTest >> testEqualsIsReflexive [
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testEqualsIsSymmetric [
+PMComplexNumberTest >> testEqualsIsSymmetric [
 	| z w |
 
  	z := 13 + 14 i.
@@ -357,25 +357,25 @@ PMComplexTest >> testEqualsIsSymmetric [
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testEqualsIsSymmetricWithRespectToFractions [
+PMComplexNumberTest >> testEqualsIsSymmetricWithRespectToFractions [
 	self assert: 1 / 2 + 0 i equals: 1 / 2.
 	self assert: 1 / 2 equals: 1 / 2 + 0 i
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testEqualsIsSymmetricWithRespectToIntegers [
+PMComplexNumberTest >> testEqualsIsSymmetricWithRespectToIntegers [
 	self assert: 1 + 0 i equals: 1.
 	self assert: 1 equals: 1 + 0 i.
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testEqualsIsSymmetricWithRespectToRealNumbers [
+PMComplexNumberTest >> testEqualsIsSymmetricWithRespectToRealNumbers [
 	self assert: 1 + 0 i equals: 1.0.
 	self assert: 1.0 equals: 1 + 0 i.
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testEqualsIsTransitive [
+PMComplexNumberTest >> testEqualsIsTransitive [
 	| z w u |
 
  	z := 4 - 1 i.
@@ -388,7 +388,7 @@ PMComplexTest >> testEqualsIsTransitive [
 ]
 
 { #category : #tests }
-PMComplexTest >> testFloatClass [
+PMComplexNumberTest >> testFloatClass [
 	"just make sure it's implemented"
 
 	self assert: ((1 + 3.4 i) imaginary isKindOf: 1 i floatClass).
@@ -396,68 +396,68 @@ PMComplexTest >> testFloatClass [
 ]
 
 { #category : #tests }
-PMComplexTest >> testHash [
+PMComplexNumberTest >> testHash [
 	| aComplex |
 	aComplex := 2 - 3 i.
 	self assert: aComplex copy hash equals: aComplex hash
 ]
 
 { #category : #'testing - type checking' }
-PMComplexTest >> testIsComplexNumberOnComplex [
+PMComplexNumberTest >> testIsComplexNumberOnComplex [
 	
 	self assert: (3 + 2i) isComplexNumber
 ]
 
 { #category : #'testing - type checking' }
-PMComplexTest >> testIsComplexNumberOnNaN [
+PMComplexNumberTest >> testIsComplexNumberOnNaN [
 	
 	self deny: Character space isComplexNumber
 ]
 
 { #category : #'testing - type checking' }
-PMComplexTest >> testIsComplexNumberOnReal [
+PMComplexNumberTest >> testIsComplexNumberOnReal [
 	
 	self deny: 5 isComplexNumber
 ]
 
 { #category : #'testing - type checking' }
-PMComplexTest >> testIsRealNumberOnComplex [
+PMComplexNumberTest >> testIsRealNumberOnComplex [
 	
 	self deny: (3 + 2i) isRealNumber
 ]
 
 { #category : #'testing - type checking' }
-PMComplexTest >> testIsRealNumberOnNaN [
+PMComplexNumberTest >> testIsRealNumberOnNaN [
 	
 	self deny: Character space isRealNumber
 ]
 
 { #category : #'testing - type checking' }
-PMComplexTest >> testIsRealNumberOnReal [
+PMComplexNumberTest >> testIsRealNumberOnReal [
 	
 	self assert: 0.5 isRealNumber
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testLn [
+PMComplexNumberTest >> testLn [
 	self assert: (Float e + 0 i) ln equals: Float e ln	"See Bug 1815 on Mantis"
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testLog [
+PMComplexNumberTest >> testLog [
 	self assert: (Float e + 0 i log: Float e) equals: Float e ln.	"See Bug 1815 on Mantis"
 	self assert: (2 + 0 i log: 2) equals: 1
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testMultiplyByI [
+PMComplexNumberTest >> testMultiplyByI [
 	| c |
 	c := 5 - 6 i.
 	self assert: c * 1 i equals: c i
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testMultiplyingAnArrayOfIntegersByAComplexNumber [
+PMComplexNumberTest >> testMultiplyingAnArrayOfIntegersByAComplexNumber [
 	| c arrayOfIntegers expected |
 	c := 6 - 6 i.
 	arrayOfIntegers := #(0 1 2 3 4 5).
@@ -467,7 +467,7 @@ PMComplexTest >> testMultiplyingAnArrayOfIntegersByAComplexNumber [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testMultiplyingArraysOfComplexNumbers [
+PMComplexNumberTest >> testMultiplyingArraysOfComplexNumbers [
 	| complexNumbersMultiplied complexNumbers expected |
 	complexNumbers := Array with: 1 + 2 i with: 3 + 4 i with: 5 + 6 i.
 	
@@ -480,7 +480,7 @@ PMComplexTest >> testMultiplyingArraysOfComplexNumbers [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testMultiplyingByPolynomials [
+PMComplexNumberTest >> testMultiplyingByPolynomials [
 	| c poly |
 	c := 1 + 1 i.
 	poly := PMPolynomial coefficients: #(1).
@@ -489,29 +489,29 @@ PMComplexTest >> testMultiplyingByPolynomials [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testNegated [
+PMComplexNumberTest >> testNegated [
 	| c |
 	c := 2 + 5 i.
 	self assert: c negated equals: -2 - 5 i
 ]
 
 { #category : #'testing - expressing complex numbers' }
-PMComplexTest >> testNew [
+PMComplexNumberTest >> testNew [
 	| c |
-	c := PMComplex new.
+	c := PMComplexNumber new.
 	self assert: c real equals: 0.
 	self assert: c imaginary equals: 0
 ]
 
 { #category : #'testing - close to' }
-PMComplexTest >> testNotCloseToRealWithPrecision [
+PMComplexNumberTest >> testNotCloseToRealWithPrecision [
 
 	self deny: 2 + 0.001i closeTo: 2 precision: 0.000001.
 	self deny: 2.001 + 0.001i closeTo: 2 precision: 0.000001.
 ]
 
 { #category : #'testing - close to' }
-PMComplexTest >> testNotCloseToWithPrecision [
+PMComplexNumberTest >> testNotCloseToWithPrecision [
 
 	self deny: 2 + 3.001i closeTo: 2 + 3i precision: 0.000001.
 	self deny: 2.001 + 3i closeTo: 2 + 3i precision: 0.000001.
@@ -519,7 +519,7 @@ PMComplexTest >> testNotCloseToWithPrecision [
 ]
 
 { #category : #tests }
-PMComplexTest >> testNumberAsComplex [
+PMComplexNumberTest >> testNumberAsComplex [
 	| minusOne |
 	minusOne := -1 asComplex.
 	self assert: minusOne real equals: -1.
@@ -529,16 +529,16 @@ PMComplexTest >> testNumberAsComplex [
 ]
 
 { #category : #'testing - expressing complex numbers' }
-PMComplexTest >> testOne [
+PMComplexNumberTest >> testOne [
 	| one |
-	one := PMComplex one.
+	one := PMComplexNumber one.
 	self assert: one isComplexNumber.
 	self assert: one real equals: 1.
 	self assert: one imaginary equals: 0
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testProductWithVector [
+PMComplexNumberTest >> testProductWithVector [
 	| v c |
 	c := 1 + 1 i.
 	v := PMVector new: 1.
@@ -548,7 +548,7 @@ PMComplexTest >> testProductWithVector [
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testPureImaginaryNumbersAreNotEqualToObjectsOfADifferentType [ 
+PMComplexNumberTest >> testPureImaginaryNumbersAreNotEqualToObjectsOfADifferentType [ 
 	self deny: 1 i = nil.
 	self deny: nil = 1 i.
 	self deny: 1 i = #(1 2 3).
@@ -556,7 +556,7 @@ PMComplexTest >> testPureImaginaryNumbersAreNotEqualToObjectsOfADifferentType [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testRaisedTo [
+PMComplexNumberTest >> testRaisedTo [
 	
 	| c c3 |
 	c := (5 - 6 i).
@@ -566,7 +566,7 @@ PMComplexTest >> testRaisedTo [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testRaisedToInteger [
+PMComplexNumberTest >> testRaisedToInteger [
 	| c c3 |
 	c := 5 - 6 i.
 	c3 := c * c * c.
@@ -575,7 +575,7 @@ PMComplexTest >> testRaisedToInteger [
 ]
 
 { #category : #tests }
-PMComplexTest >> testRandom [
+PMComplexNumberTest >> testRandom [
 	| random c r |
 	random := Random new.
 	c := random next + random next i.
@@ -585,7 +585,7 @@ PMComplexTest >> testRandom [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testReciprocal [
+PMComplexNumberTest >> testReciprocal [
 	"self run: #testReciprocal"
 
 	"self debug: #testReciprocal"
@@ -596,7 +596,7 @@ PMComplexTest >> testReciprocal [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testSecureDivision1 [
+PMComplexNumberTest >> testSecureDivision1 [
 	"self run: #testSecureDivision1"
 	"self debug: #testSecureDivision1"
 	
@@ -609,7 +609,7 @@ PMComplexTest >> testSecureDivision1 [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testSecureDivision2 [
+PMComplexNumberTest >> testSecureDivision2 [
 	"self run: #testSecureDivision2"
 	"self debug: #testSecureDivision2"
 	
@@ -622,7 +622,7 @@ PMComplexTest >> testSecureDivision2 [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testSin [
+PMComplexNumberTest >> testSin [
 	| c c2 |
 	c := (2 + 0 i).
 	self assert: (c sin real closeTo: c real sin).
@@ -634,7 +634,7 @@ PMComplexTest >> testSin [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testSinh [
+PMComplexNumberTest >> testSinh [
 	| c c2 |
 	c := (2 + 0 i).
 	self assert: (c sinh real closeTo: c real sinh).
@@ -652,12 +652,12 @@ PMComplexTest >> testSinh [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testSquareRootOfANegativeRealNumberIsPureImaginary [
+PMComplexNumberTest >> testSquareRootOfANegativeRealNumberIsPureImaginary [
 
 	"Given z = -4 + 0 i, the square root is 2 i"
 
 	| squareRoot z |
-	z := PMComplex real: -4 imaginary: 0.
+	z := PMComplexNumber real: -4 imaginary: 0.
 	
 	squareRoot := z sqrt.
 	
@@ -665,9 +665,9 @@ PMComplexTest >> testSquareRootOfANegativeRealNumberIsPureImaginary [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testSquareRootOfComplexNumberIsAComplexNumber [
+PMComplexNumberTest >> testSquareRootOfComplexNumberIsAComplexNumber [
 	| squareRoot z |
-	z := PMComplex real: 2 imaginary: 2.
+	z := PMComplexNumber real: 2 imaginary: 2.
 	
 	squareRoot := z sqrt.
 
@@ -676,9 +676,9 @@ PMComplexTest >> testSquareRootOfComplexNumberIsAComplexNumber [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testSquareRootOfNegativePureImaginaryNumberIsAComplexNumberWithRealAndImaginaryParts [
+PMComplexNumberTest >> testSquareRootOfNegativePureImaginaryNumberIsAComplexNumberWithRealAndImaginaryParts [
    | squareRoot expected pureImaginaryNumber |
-	pureImaginaryNumber := PMComplex real: 0 imaginary: -4.
+	pureImaginaryNumber := PMComplexNumber real: 0 imaginary: -4.
 	
 	squareRoot := pureImaginaryNumber sqrt.
 
@@ -689,12 +689,12 @@ PMComplexTest >> testSquareRootOfNegativePureImaginaryNumberIsAComplexNumberWith
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testSquareRootOfPositivePureImaginaryNumberIsAComplexNumberWithRealAndImaginaryParts [
+PMComplexNumberTest >> testSquareRootOfPositivePureImaginaryNumberIsAComplexNumberWithRealAndImaginaryParts [
 
 	"e.g. square root of 4 i = root(2) + i root(2)"
 
 	| squareRoot expected pureImaginaryNumber |
-	pureImaginaryNumber := PMComplex real: 0 imaginary: 4.
+	pureImaginaryNumber := PMComplexNumber real: 0 imaginary: 4.
 	
 	squareRoot := pureImaginaryNumber sqrt.
 
@@ -704,21 +704,21 @@ PMComplexTest >> testSquareRootOfPositivePureImaginaryNumberIsAComplexNumberWith
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testSquareRootOfPositiveRealNumberIsAComplexNumberWithOnlyARealPart [
+PMComplexNumberTest >> testSquareRootOfPositiveRealNumberIsAComplexNumberWithOnlyARealPart [
 
 	"Given z = 6 + 0 i, then root z = root 6"
 
 	| squareRoot expected positiveRealNumber |
-	positiveRealNumber := PMComplex real: 6 imaginary: 0.
+	positiveRealNumber := PMComplexNumber real: 6 imaginary: 0.
 	
 	squareRoot := positiveRealNumber sqrt.
 
-	expected := PMComplex real: 6 sqrt imaginary: 0.
+	expected := PMComplexNumber real: 6 sqrt imaginary: 0.
 	self assert: squareRoot equals: expected
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testSquareRootOfVeryLargeRealAndVerySmallImaginary [
+PMComplexNumberTest >> testSquareRootOfVeryLargeRealAndVerySmallImaginary [
 	"This may cause problems because of the loss of precision.
 	Very large and very small floating point numbers have different units of least precision.
 	
@@ -737,7 +737,7 @@ PMComplexTest >> testSquareRootOfVeryLargeRealAndVerySmallImaginary [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testSquareRootOfVerySmallRealAndVeryLargeImaginary [
+PMComplexNumberTest >> testSquareRootOfVerySmallRealAndVeryLargeImaginary [
 	"This may cause problems because of the loss of precision.
 	Very large and very small floating point numbers have different units of least precision.
 	
@@ -756,16 +756,16 @@ PMComplexTest >> testSquareRootOfVerySmallRealAndVeryLargeImaginary [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testSquareRootOfZeroIsZero [
+PMComplexNumberTest >> testSquareRootOfZeroIsZero [
 	| squareRoot expected |
-	squareRoot := PMComplex zero sqrt .
+	squareRoot := PMComplexNumber zero sqrt .
 	
-	expected := PMComplex zero.
+	expected := PMComplexNumber zero.
 	self assert: squareRoot equals: expected.
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testSquared [
+PMComplexNumberTest >> testSquared [
 	| c c2 |
 	c := 6 - 6 i.
 	c2 := c squared.
@@ -774,7 +774,7 @@ PMComplexTest >> testSquared [
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testSubtractingPolynomials [
+PMComplexNumberTest >> testSubtractingPolynomials [
 	| c poly |
 	poly := PMPolynomial coefficients: #(1 2 3).
 	c := 1 + 3 i.
@@ -783,7 +783,7 @@ PMComplexTest >> testSubtractingPolynomials [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testTan [
+PMComplexNumberTest >> testTan [
 	| c c2 |
 	c := (2 + 0 i).
 	self assert: (c tan real closeTo: c real tan).
@@ -795,7 +795,7 @@ PMComplexTest >> testTan [
 ]
 
 { #category : #'testing - mathematical functions' }
-PMComplexTest >> testTanh [
+PMComplexNumberTest >> testTanh [
 	| c c2 |
 	c := (2 + 0 i).
 	self assert: (c tanh real closeTo: c real tanh).
@@ -807,7 +807,7 @@ PMComplexTest >> testTanh [
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testTwoComplexNumbersWithDifferentImaginaryPartsAreNotEqual [
+PMComplexNumberTest >> testTwoComplexNumbersWithDifferentImaginaryPartsAreNotEqual [
 	| z w |
  	z := 1 + 3 i.
  	w := 1 + 2 i.
@@ -816,7 +816,7 @@ PMComplexTest >> testTwoComplexNumbersWithDifferentImaginaryPartsAreNotEqual [
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testTwoComplexNumbersWithDifferentRealPartsAreNotEqual [
+PMComplexNumberTest >> testTwoComplexNumbersWithDifferentRealPartsAreNotEqual [
 	| z w |
  	z := 4 + 3 i.
  	w := -7 + 3 i.
@@ -825,16 +825,16 @@ PMComplexTest >> testTwoComplexNumbersWithDifferentRealPartsAreNotEqual [
 ]
 
 { #category : #'testing - expressing complex numbers' }
-PMComplexTest >> testWeCanWriteComplexNumbersWhoseRealAndImaginaryPartsAreFractions [
+PMComplexNumberTest >> testWeCanWriteComplexNumbersWhoseRealAndImaginaryPartsAreFractions [
 	| z |
-	z := PMComplex real: 3 / 5 imaginary: 4 / 5.
+	z := PMComplexNumber real: 3 / 5 imaginary: 4 / 5.
 	 
 	self assert: (z real) equals: (Fraction numerator: 3 denominator: 5).
 	self assert: (z imaginary) equals: (Fraction numerator: 4 denominator: 5).
 ]
 
 { #category : #'testing - expressing complex numbers' }
-PMComplexTest >> testWeCannotWriteFractionsOfComplexNumbersWithDenominatorNormalized [
+PMComplexNumberTest >> testWeCannotWriteFractionsOfComplexNumbersWithDenominatorNormalized [
 
 	| z w numerator denominator |
 	z := 1 + 2 i.
@@ -846,20 +846,20 @@ PMComplexTest >> testWeCannotWriteFractionsOfComplexNumbersWithDenominatorNormal
 ]
 
 { #category : #'testing - expressing complex numbers' }
-PMComplexTest >> testWeCannotWriteFractionsWhoseNumeratorAndDenominatorAreComplexNumbers [
+PMComplexNumberTest >> testWeCannotWriteFractionsWhoseNumeratorAndDenominatorAreComplexNumbers [
 	| numerator denominator |
 	"It is interesting that we cannot instanciate a fraction of the form z/w"
 	"Perhaps, we could do something like z * (w*)/ |w|**2"
-	numerator := PMComplex real: 1 imaginary: 1.
-	denominator := PMComplex real: 3 imaginary: 4 .
+	numerator := PMComplexNumber real: 1 imaginary: 1.
+	denominator := PMComplexNumber real: 3 imaginary: 4 .
 
 	self should: [ Fraction numerator: numerator denominator: denominator ] raise: Exception .
 ]
 
 { #category : #'testing - expressing complex numbers' }
-PMComplexTest >> testZero [
+PMComplexNumberTest >> testZero [
 	| z |
-	z := PMComplex zero.
+	z := PMComplexNumber zero.
 	self assert: z isZero.
 	self assert: z isComplexNumber.
 	self assert: z real isZero.
@@ -867,12 +867,12 @@ PMComplexTest >> testZero [
 ]
 
 { #category : #'testing - equality' }
-PMComplexTest >> testZeroComplexNumberIsEqualToIntegerZero [
+PMComplexNumberTest >> testZeroComplexNumberIsEqualToIntegerZero [
 	self assert: 0 i equals: 0.
  	self assert: 0 equals: 0 i.
 ]
 
 { #category : #'testing - arithmetic' }
-PMComplexTest >> testZeroComplexNumbersDoNotHaveAReciprocal [
-	self should: [ PMComplex zero reciprocal ] raise: ZeroDivide.
+PMComplexNumberTest >> testZeroComplexNumbersDoNotHaveAReciprocal [
+	self should: [ PMComplexNumber zero reciprocal ] raise: ZeroDivide.
 ]


### PR DESCRIPTION
Issue: #191 
**Breaking Change**

- Renamed the PMComplex class and its Test Case to PMComplexNumber and PMComplexNumberTest respectively;
- migrated clients.

I have chosen to rename the package as a separate PR, as this step has proved difficult. 