### PR TITLE
Break Up Moore Penrose Test Into Smaller Tests For Clarity and Ease of Debugging

### DIFF
--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -6,6 +6,7 @@ Class {
 
 { #category : #running }
 PMQRTest >> assert: inverse isInverseOf: aMatrix [
+	"A~ * A = A * A~ = I"
 
 	| identityMatrix |
 	identityMatrix := inverse * aMatrix.
@@ -13,7 +14,8 @@ PMQRTest >> assert: inverse isInverseOf: aMatrix [
 	self assert: identityMatrix * inverse closeTo: inverse.
 	self assert: identityMatrix transpose closeTo: identityMatrix.
 	identityMatrix := aMatrix * inverse.
-	self assert: identityMatrix transpose closeTo: identityMatrix
+	self assert: identityMatrix transpose closeTo: identityMatrix.
+	self assert: (identityMatrix * aMatrix) closeTo: aMatrix.
 ]
 
 { #category : #running }

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -16,15 +16,15 @@ PMQRTest >> assert: inverse isMoorePenroseInverseOf: aMatrix [
 	"
 	self assert: aMatrix * inverse * aMatrix closeTo: aMatrix.
 	self assert: inverse * aMatrix * inverse closeTo: inverse.
+	
+	identityMatrix := aMatrix * inverse.
+	self assert: identityMatrix transpose closeTo: identityMatrix.
+	self assert: identityMatrix * aMatrix closeTo: aMatrix.
 
 	"Pseudoinversion commutes with transposition, complex conjugation, and taking the conjugate transpose"
 	self
 		assert: aMatrix transpose mpInverse
 		closeTo: aMatrix mpInverse transpose.
-
-	identityMatrix := aMatrix * inverse.
-	self assert: identityMatrix transpose closeTo: identityMatrix.
-	self assert: identityMatrix * aMatrix closeTo: aMatrix
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -25,10 +25,8 @@ PMQRTest >> assert: inverse isMoorePenroseInverseOf: aMatrix [
 ]
 
 { #category : #tests }
-PMQRTest >> testMoorePenroseInverse [
-
+PMQRTest >> testMoorePenroseInverseOfLargeNonRandomMatrix [
 	| a inverse |
-	
 	a := PMMatrix new initializeRows:
 		     #( #( 5 40 1 2.5 ) #( 0 0 1 2.5 ) #( 0 0 1 2.5 ) ).
 	inverse := a mpInverse .
@@ -37,12 +35,6 @@ PMQRTest >> testMoorePenroseInverse [
 	a := a transpose.
 	inverse := a mpInverse .
 	self assert: inverse isMoorePenroseInverseOf: a.
-	
-	3 timesRepeat: [ 
-		a := PMMatrix rows: 3 columns: 3 random: 1.0.
-		self assert: (a mpInverse closeTo: a inverse).
-		a := PMSymmetricMatrix new: 4 random: 1.0.
-		self assert: (a mpInverse closeTo: a inverse) ]
 ]
 
 { #category : #tests }
@@ -63,6 +55,17 @@ PMQRTest >> testMoorePenroseInverseOfProductOfMatrices [
 	a := a * (PMMatrix rows: 3 columns: 3 random: 5.0).
 	inverse := a mpInverse .
 	self assert: inverse isMoorePenroseInverseOf: a.
+]
+
+{ #category : #tests }
+PMQRTest >> testMoorePenroseInverseRepeatedly [
+
+	| a |
+	3 timesRepeat: [ 
+		a := PMMatrix rows: 3 columns: 3 random: 1.0.
+		self assert: (a mpInverse closeTo: a inverse).
+		a := PMSymmetricMatrix new: 4 random: 1.0.
+		self assert: (a mpInverse closeTo: a inverse) ]
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -5,14 +5,20 @@ Class {
 }
 
 { #category : #running }
-PMQRTest >> assert: inverse isInverseOf: aMatrix [
-	"A~ * A = A * A~ = I"
+PMQRTest >> assert: inverse isMoorePenroseInverseOf: aMatrix [
+	"https://en.wikipedia.org/wiki/Moore–Penrose_inverse#Definition"
 
 	| identityMatrix |
-	identityMatrix := inverse * aMatrix.
-	self assert: (aMatrix * identityMatrix closeTo: aMatrix).
-	self assert: identityMatrix * inverse closeTo: inverse.
-	self assert: identityMatrix transpose closeTo: identityMatrix.
+	"These two assertions are what define a pseudoinverse. They are known as
+	the Moore–Penrose conditions of which there are four, but here we have two. The other two
+	are that (A * A+) and A+ * A are Hermitian.
+	"
+	self assert: (aMatrix * inverse * aMatrix closeTo: aMatrix).
+	self assert: inverse * aMatrix * inverse closeTo: inverse.
+	
+	"Pseudoinversion commutes with transposition, complex conjugation, and taking the conjugate transpose"
+	self assert: aMatrix transpose mpInverse closeTo: aMatrix mpInverse transpose.
+	
 	identityMatrix := aMatrix * inverse.
 	self assert: identityMatrix transpose closeTo: identityMatrix.
 	self assert: (identityMatrix * aMatrix) closeTo: aMatrix.
@@ -23,7 +29,7 @@ PMQRTest >> mpTestFunction: aMatrix [
 
 	| inverse |
 	inverse := aMatrix mpInverse.
-	self assert: inverse isInverseOf: aMatrix.
+	self assert: inverse isMoorePenroseInverseOf: aMatrix.
 
 ]
 

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -61,7 +61,12 @@ PMQRTest >> testMoorePenroseInverseOfProductOfMatrices [
 ]
 
 { #category : #tests }
-PMQRTest >> testMoorePenroseInverseOfRandomMatrixIsAPseudoInverse [
+PMQRTest >> testMoorePenroseInverseOfRandomMatrixIsAnInverse [
+"
+Proofs for the properties below can be found in literature:
+If A has real entries, then so does A+
+If A is invertible, its pseudoinverse is its inverse. That is, A+=A**−1
+"
 
 	| a |
 	a := PMSymmetricMatrix new: 4 random: 1.0.

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -7,13 +7,13 @@ Class {
 { #category : #running }
 PMQRTest >> mpTestFunction: aMatrix [
 
-	| inv mult |
-	inv := aMatrix mpInverse.
-	mult := inv * aMatrix.
-	self assert: (aMatrix * mult closeTo: aMatrix).
-	self assert: mult * inv closeTo: inv.
-	self assert: mult transpose closeTo: mult.
-	mult := aMatrix * inv.
+	| inverse mult identityMatrix |
+	inverse := aMatrix mpInverse.
+	identityMatrix := inverse * aMatrix.
+	self assert: (aMatrix * identityMatrix closeTo: aMatrix).
+	self assert: identityMatrix * inverse closeTo: inverse.
+	self assert: identityMatrix transpose closeTo: identityMatrix.
+	mult := aMatrix * inverse.
 	self assert: mult transpose closeTo: mult
 ]
 

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -14,7 +14,7 @@ PMQRTest >> assert: inverse isMoorePenroseInverseOf: aMatrix [
 	the Moore–Penrose conditions of which there are four, but here we have two. The other two
 	are that (A * A+) and A+ * A are Hermitian.
 	"
-	self assert: (aMatrix * inverse * aMatrix closeTo: aMatrix).
+	self assert: aMatrix * inverse * aMatrix closeTo: aMatrix.
 	self assert: inverse * aMatrix * inverse closeTo: inverse.
 
 	"Pseudoinversion commutes with transposition, complex conjugation, and taking the conjugate transpose"

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -24,29 +24,28 @@ PMQRTest >> assert: inverse isMoorePenroseInverseOf: aMatrix [
 	self assert: (identityMatrix * aMatrix) closeTo: aMatrix.
 ]
 
-{ #category : #running }
-PMQRTest >> mpTestFunction: aMatrix [
-
-	| inverse |
-	inverse := aMatrix mpInverse.
-	self assert: inverse isMoorePenroseInverseOf: aMatrix.
-
-]
-
 { #category : #tests }
 PMQRTest >> testMoorePenroseInverse [
 
-	| a |
+	| a inverse |
 	a := PMMatrix new initializeRows:
 		     #( #( 5 40 1 ) #( 0 0 1 ) #( 0 0 1 ) ).
-	self mpTestFunction: a.
+	inverse := a mpInverse .
+	self assert: inverse isMoorePenroseInverseOf: a.
+	
 	a := a * (PMMatrix rows: 3 columns: 3 random: 5.0).
-	self mpTestFunction: a.
+	inverse := a mpInverse .
+	self assert: inverse isMoorePenroseInverseOf: a.
+	
 	a := PMMatrix new initializeRows:
 		     #( #( 5 40 1 2.5 ) #( 0 0 1 2.5 ) #( 0 0 1 2.5 ) ).
-	self mpTestFunction: a.
+	inverse := a mpInverse .
+	self assert: inverse isMoorePenroseInverseOf: a.
+	
 	a := a transpose.
-	self mpTestFunction: a.
+	inverse := a mpInverse .
+	self assert: inverse isMoorePenroseInverseOf: a.
+	
 	3 timesRepeat: [ 
 		a := PMMatrix rows: 3 columns: 3 random: 1.0.
 		self assert: (a mpInverse closeTo: a inverse).

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -61,7 +61,7 @@ PMQRTest >> testMoorePenroseInverseOfProductOfMatrices [
 ]
 
 { #category : #tests }
-PMQRTest >> testMoorePenroseInverseOfRandomMatrix [
+PMQRTest >> testMoorePenroseInverseOfRandomMatrixIsAPseudoInverse [
 
 	| a |
 	a := PMSymmetricMatrix new: 4 random: 1.0.

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -18,7 +18,7 @@ PMQRTest >> mpTestFunction: aMatrix [
 ]
 
 { #category : #tests }
-PMQRTest >> testMPInverse [
+PMQRTest >> testMoorePenroseInverse [
 
 	| a |
 	a := PMMatrix new initializeRows:

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -6,6 +6,7 @@ Class {
 
 { #category : #running }
 PMQRTest >> assert: inverse isMoorePenroseInverseOf: aMatrix [
+
 	"https://en.wikipedia.org/wiki/Moore–Penrose_inverse#Definition"
 
 	| identityMatrix |
@@ -15,13 +16,15 @@ PMQRTest >> assert: inverse isMoorePenroseInverseOf: aMatrix [
 	"
 	self assert: (aMatrix * inverse * aMatrix closeTo: aMatrix).
 	self assert: inverse * aMatrix * inverse closeTo: inverse.
-	
+
 	"Pseudoinversion commutes with transposition, complex conjugation, and taking the conjugate transpose"
-	self assert: aMatrix transpose mpInverse closeTo: aMatrix mpInverse transpose.
-	
+	self
+		assert: aMatrix transpose mpInverse
+		closeTo: aMatrix mpInverse transpose.
+
 	identityMatrix := aMatrix * inverse.
 	self assert: identityMatrix transpose closeTo: identityMatrix.
-	self assert: (identityMatrix * aMatrix) closeTo: aMatrix.
+	self assert: identityMatrix * aMatrix closeTo: aMatrix
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -65,7 +65,7 @@ PMQRTest >> testMoorePenroseInverseOfRandomMatrixIsAnInverse [
 "
 Proofs for the properties below can be found in literature:
 If A has real entries, then so does A+
-If A is invertible, its pseudoinverse is its inverse. That is, A+=A**−1
+If A is invertible, its pseudoinverse is its inverse. That is, A+ = A**−1
 "
 
 	| a |

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -7,14 +7,14 @@ Class {
 { #category : #running }
 PMQRTest >> mpTestFunction: aMatrix [
 
-	| inverse mult identityMatrix |
+	| inverse identityMatrix |
 	inverse := aMatrix mpInverse.
 	identityMatrix := inverse * aMatrix.
 	self assert: (aMatrix * identityMatrix closeTo: aMatrix).
 	self assert: identityMatrix * inverse closeTo: inverse.
 	self assert: identityMatrix transpose closeTo: identityMatrix.
-	mult := aMatrix * inverse.
-	self assert: mult transpose closeTo: mult
+	identityMatrix := aMatrix * inverse.
+	self assert: identityMatrix transpose closeTo: identityMatrix
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -25,16 +25,16 @@ PMQRTest >> assert: inverse isMoorePenroseInverseOf: aMatrix [
 ]
 
 { #category : #tests }
-PMQRTest >> testMoorePenroseInverseOfLargeNonRandomMatrix [
-	| a inverse |
+PMQRTest >> testMoorePenroseInverseOfLargeNonRandomMatrixAndItsTranspose [
+	| a inverse transposeOfA |
 	a := PMMatrix new initializeRows:
 		     #( #( 5 40 1 2.5 ) #( 0 0 1 2.5 ) #( 0 0 1 2.5 ) ).
 	inverse := a mpInverse .
 	self assert: inverse isMoorePenroseInverseOf: a.
 	
-	a := a transpose.
-	inverse := a mpInverse .
-	self assert: inverse isMoorePenroseInverseOf: a.
+	transposeOfA := a transpose.
+	inverse := transposeOfA mpInverse .
+	self assert: inverse isMoorePenroseInverseOf: transposeOfA.
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -58,14 +58,11 @@ PMQRTest >> testMoorePenroseInverseOfProductOfMatrices [
 ]
 
 { #category : #tests }
-PMQRTest >> testMoorePenroseInverseRepeatedly [
+PMQRTest >> testMoorePenroseInverseOfRandomMatrix [
 
 	| a |
-	3 timesRepeat: [ 
-		a := PMMatrix rows: 3 columns: 3 random: 1.0.
-		self assert: (a mpInverse closeTo: a inverse).
-		a := PMSymmetricMatrix new: 4 random: 1.0.
-		self assert: (a mpInverse closeTo: a inverse) ]
+	a := PMSymmetricMatrix new: 4 random: 1.0.
+	self assert: (a mpInverse closeTo: a inverse)
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -28,14 +28,6 @@ PMQRTest >> assert: inverse isMoorePenroseInverseOf: aMatrix [
 PMQRTest >> testMoorePenroseInverse [
 
 	| a inverse |
-	a := PMMatrix new initializeRows:
-		     #( #( 5 40 1 ) #( 0 0 1 ) #( 0 0 1 ) ).
-	inverse := a mpInverse .
-	self assert: inverse isMoorePenroseInverseOf: a.
-	
-	a := a * (PMMatrix rows: 3 columns: 3 random: 5.0).
-	inverse := a mpInverse .
-	self assert: inverse isMoorePenroseInverseOf: a.
 	
 	a := PMMatrix new initializeRows:
 		     #( #( 5 40 1 2.5 ) #( 0 0 1 2.5 ) #( 0 0 1 2.5 ) ).
@@ -51,6 +43,26 @@ PMQRTest >> testMoorePenroseInverse [
 		self assert: (a mpInverse closeTo: a inverse).
 		a := PMSymmetricMatrix new: 4 random: 1.0.
 		self assert: (a mpInverse closeTo: a inverse) ]
+]
+
+{ #category : #tests }
+PMQRTest >> testMoorePenroseInverseOfNonRandomMatrix [
+	| a inverse |
+	a := PMMatrix new initializeRows:
+		     #( #( 5 40 1 ) #( 0 0 1 ) #( 0 0 1 ) ).
+	inverse := a mpInverse .
+	self assert: inverse isMoorePenroseInverseOf: a.
+]
+
+{ #category : #tests }
+PMQRTest >> testMoorePenroseInverseOfProductOfMatrices [
+	| a inverse |
+	a := PMMatrix new initializeRows:
+		     #( #( 5 40 1 ) #( 0 0 1 ) #( 0 0 1 ) ).
+	
+	a := a * (PMMatrix rows: 3 columns: 3 random: 5.0).
+	inverse := a mpInverse .
+	self assert: inverse isMoorePenroseInverseOf: a.
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -5,16 +5,24 @@ Class {
 }
 
 { #category : #running }
-PMQRTest >> mpTestFunction: aMatrix [
+PMQRTest >> assert: inverse isInverseOf: aMatrix [
 
-	| inverse identityMatrix |
-	inverse := aMatrix mpInverse.
+	| identityMatrix |
 	identityMatrix := inverse * aMatrix.
 	self assert: (aMatrix * identityMatrix closeTo: aMatrix).
 	self assert: identityMatrix * inverse closeTo: inverse.
 	self assert: identityMatrix transpose closeTo: identityMatrix.
 	identityMatrix := aMatrix * inverse.
 	self assert: identityMatrix transpose closeTo: identityMatrix
+]
+
+{ #category : #running }
+PMQRTest >> mpTestFunction: aMatrix [
+
+	| inverse |
+	inverse := aMatrix mpInverse.
+	self assert: inverse isInverseOf: aMatrix.
+
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Issue: #279 

I have started by trying to improve clarity in the tests by breaking the test up into well named smaller ones. I hypothesise that it will pin point which scenario is failing.