### PR TITLE
QR Decomposition Method Object Refactoring

### DIFF
--- a/src/Math-Core/PMVector.class.st
+++ b/src/Math-Core/PMVector.class.st
@@ -220,6 +220,11 @@ PMVector >> isReal [
 	^ self allSatisfy: [ :each | each isRealNumber ].
 ]
 
+{ #category : #testing }
+PMVector >> isZero [
+ ^ self allSatisfy: [ :element | element = 0 ]
+]
+
 { #category : #operation }
 PMVector >> log [
 	"Apply log function to every element of a vector"

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -660,6 +660,14 @@ PMMatrix >> lupInverse [
 		ifNotNil: [ :i | ^ self class rows: i ]
 ]
 
+{ #category : #operation }
+PMMatrix >> minor: rowIndex and: columnIndex [
+
+	^ PMMatrix rows:
+		  ((self rows allButFirst: columnIndex) collect: [ :aRow | 
+			   aRow allButFirst: rowIndex ])
+]
+
 { #category : #'as yet unclassified' }
 PMMatrix >> mpInverse [
 	"Moore Penrose Inverse. "

--- a/src/Math-Matrix/PMMatrix.class.st
+++ b/src/Math-Matrix/PMMatrix.class.st
@@ -891,6 +891,12 @@ PMMatrix >> rowsDo: aBlock [
 	^ rows do: aBlock
 ]
 
+{ #category : #iterators }
+PMMatrix >> rowsWithIndexDo: aBlock [
+
+	^ rows withIndexDo: aBlock
+]
+
 { #category : #transformation }
 PMMatrix >> scaleBy: aNumber [
 

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -42,9 +42,7 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 		q := q * householderMatrix.
 		rowIndex := col - 1.
 		columnIndex := col - 1.
-		i := PMMatrix rows:
-			     ((r rows allButFirst: columnIndex) collect: [ :aRow | 
-				      aRow allButFirst: rowIndex ]).
+		i := r minor: rowIndex and: columnIndex.
 		i := i - ((householderVector at: 2) tensorProduct:
 			      (householderVector at: 1) * (householderVector at: 2) * i).
 		i rows withIndexDo: [ :aRow :index | 

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -6,7 +6,9 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'matrixToDecompose',
-		'colSize'
+		'colSize',
+		'r',
+		'q'
 	],
 	#category : #'Math-Matrix'
 }
@@ -27,9 +29,7 @@ that describes the mechanics:
 https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 "
 
-	| identityMatrix q r householderVector i |
-	r := self initialRMatrix.
-	q := self initialQMatrix.
+	| identityMatrix householderVector i |
 	identityMatrix := PMSymmetricMatrix identity: colSize.
 	1 to: self numberOfColumns do: [ :col | 
 		| columnVectorFromRMatrix householderMatrix v |
@@ -66,24 +66,25 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 { #category : #arithmetic }
 PMQRDecomposition >> decomposeWithPivot [
 
-	| identMat q r householderVector i lengthArray rank mx pivot |
+	| identMat householderVector i lengthArray rank mx pivot |
 	lengthArray := matrixToDecompose columnsCollect: [ :col | col * col ].
 	mx := lengthArray indexOf: lengthArray max.
 	pivot := Array new: lengthArray size.
 	rank := 0.
-	r := self initialRMatrix.
-	q := self initialQMatrix.
 	identMat := PMSymmetricMatrix identity: colSize.
 	[ 
 	rank := rank + 1.
 	pivot at: rank put: mx.
 	r swapColumn: rank withColumn: mx.
 	lengthArray swap: rank with: mx.
-	householderVector := (r columnVectorAt: rank size: colSize) householder.
+	householderVector := (r columnVectorAt: rank size: colSize)
+		                     householder.
 	i := (PMVector new: rank - 1 withAll: 0) , (householderVector at: 2).
-	q := q * (identMat - ((householderVector at: 1) * i tensorProduct: i)).
+	q := q
+	     * (identMat - ((householderVector at: 1) * i tensorProduct: i)).
 	i := r minor: rank - 1 and: rank - 1.
-	i := i - ((householderVector at: 2) tensorProduct: (householderVector at: 1) * (householderVector at: 2) * i).
+	i := i - ((householderVector at: 2) tensorProduct:
+		      (householderVector at: 1) * (householderVector at: 2) * i).
 	i rows withIndexDo: [ :aRow :index | 
 		aRow withIndexDo: [ :n :c | 
 			r
@@ -141,4 +142,6 @@ PMQRDecomposition >> of: matrix [
 
 	matrixToDecompose := matrix.
 	colSize := matrixToDecompose numberOfRows.
+		r := self initialRMatrix.
+	q := self initialQMatrix.
 ]

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -32,13 +32,13 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 	q := self initialQMatrix.
 	identityMatrix := PMSymmetricMatrix identity: colSize.
 	1 to: self numberOfColumns do: [ :col | 
-		| columnVectorFromRMatrix householderMatrix |
+		| columnVectorFromRMatrix householderMatrix v |
 		columnVectorFromRMatrix := r columnVectorAt: col size: colSize.
 		householderVector := columnVectorFromRMatrix householder.
-		i := (PMVector zeros: col - 1) , (householderVector at: 2).
+		v := (PMVector zeros: col - 1) , (householderVector at: 2).
 		householderMatrix := identityMatrix
 		                     -
-		                     ((householderVector at: 1) * i tensorProduct: i).
+		                     ((householderVector at: 1) * v tensorProduct: v).
 		q := q * householderMatrix.
 		i := r minor: col - 1 and: col - 1.
 		i := i - ((householderVector at: 2) tensorProduct:

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -66,17 +66,17 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 { #category : #arithmetic }
 PMQRDecomposition >> decomposeWithPivot [
 
-	| identMat householderVector i normSquaredVector rank mx pivot |
-	normSquaredVector := matrixToDecompose columnsCollect: [ :columnVector | columnVector * columnVector ].
-	mx := normSquaredVector indexOf: normSquaredVector max.
-	pivot := Array new: normSquaredVector size.
+	| identMat householderVector i vectorOfnormSquareds rank mx pivot |
+	vectorOfnormSquareds := matrixToDecompose columnsCollect: [ :columnVector | columnVector * columnVector ].
+	mx := vectorOfnormSquareds indexOf: vectorOfnormSquareds max.
+	pivot := Array new: vectorOfnormSquareds size.
 	rank := 0.
 	identMat := PMSymmetricMatrix identity: colSize.
 	[ 
 	rank := rank + 1.
 	pivot at: rank put: mx.
 	r swapColumn: rank withColumn: mx.
-	normSquaredVector swap: rank with: mx.
+	vectorOfnormSquareds swap: rank with: mx.
 	householderVector := (r columnVectorAt: rank size: colSize)
 		                     householder.
 	i := (PMVector new: rank - 1 withAll: 0) , (householderVector at: 2).
@@ -93,16 +93,16 @@ PMQRDecomposition >> decomposeWithPivot [
 				put: ((n closeTo: 0)
 						 ifTrue: [ 0 ]
 						 ifFalse: [ n ]) ] ].
-	rank + 1 to: normSquaredVector size do: [ :ind | 
-		normSquaredVector
+	rank + 1 to: vectorOfnormSquareds size do: [ :ind | 
+		vectorOfnormSquareds
 			at: ind
-			put: (normSquaredVector at: ind) - (r rowAt: rank columnAt: ind) squared ].
-	rank < normSquaredVector size
+			put: (vectorOfnormSquareds at: ind) - (r rowAt: rank columnAt: ind) squared ].
+	rank < vectorOfnormSquareds size
 		ifTrue: [ 
-			mx := (normSquaredVector copyFrom: rank + 1 to: normSquaredVector size) max.
+			mx := (vectorOfnormSquareds copyFrom: rank + 1 to: vectorOfnormSquareds size) max.
 			(mx closeTo: 0) ifTrue: [ mx := 0 ].
 			mx := mx > 0
-				      ifTrue: [ normSquaredVector indexOf: mx startingAt: rank + 1 ]
+				      ifTrue: [ vectorOfnormSquareds indexOf: mx startingAt: rank + 1 ]
 				      ifFalse: [ 0 ] ]
 		ifFalse: [ mx := 0 ].
 	mx > 0 ] whileTrue.

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -54,7 +54,7 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 							 ifTrue: [ 0 ]
 							 ifFalse: [ n ]) ] ] ].
 	i := 0.
-	[ (r rowAt: colSize) allSatisfy: [ :n | n = 0 ] ] whileTrue: [ 
+	[ (r rowAt: colSize) isZero ] whileTrue: [ 
 		i := i + 1.
 		colSize := colSize - 1 ].
 	i > 0 ifTrue: [ 

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -32,7 +32,7 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 	q := self initialQMatrix.
 	identityMatrix := PMSymmetricMatrix identity: colSize.
 	1 to: self numberOfColumns do: [ :col | 
-		| columnVectorFromRMatrix householderMatrix dimension |
+		| columnVectorFromRMatrix householderMatrix rowIndex columnIndex |
 		columnVectorFromRMatrix := r columnVectorAt: col size: colSize.
 		householderVector := columnVectorFromRMatrix householder.
 		i := (PMVector zeros: col - 1) , (householderVector at: 2).
@@ -40,10 +40,11 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 		                     -
 		                     ((householderVector at: 1) * i tensorProduct: i).
 		q := q * householderMatrix.
-		dimension := col - 1.
+		rowIndex := col - 1.
+		columnIndex := col - 1.
 		i := PMMatrix rows:
-			     ((r rows allButFirst: dimension) collect: [ :aRow | 
-				      aRow allButFirst: dimension ]).
+			     ((r rows allButFirst: columnIndex) collect: [ :aRow | 
+				      aRow allButFirst: rowIndex ]).
 		i := i - ((householderVector at: 2) tensorProduct:
 			      (householderVector at: 1) * (householderVector at: 2) * i).
 		i rows withIndexDo: [ :aRow :index | 

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -76,6 +76,7 @@ PMQRDecomposition >> decomposeWithPivot [
 	rank := 0.
 	identMat := PMSymmetricMatrix identity: colSize.
 	[ 
+	| householderMatrix |
 	rank := rank + 1.
 	pivot at: rank put: mx.
 	r swapColumn: rank withColumn: mx.
@@ -83,8 +84,10 @@ PMQRDecomposition >> decomposeWithPivot [
 	householderVector := (r columnVectorAt: rank size: colSize)
 		                     householder.
 	v := (PMVector zeros: rank - 1) , (householderVector at: 2).
-	q := q
-	     * (identMat - ((householderVector at: 1) * v tensorProduct: v)).
+	householderMatrix := identMat
+	                     -
+	                     ((householderVector at: 1) * v tensorProduct: v).
+	q := q * householderMatrix.
 	matrixOfMinor := r minor: rank - 1 and: rank - 1.
 	matrixOfMinor := matrixOfMinor
 	                 - ((householderVector at: 2) tensorProduct:

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -29,7 +29,7 @@ that describes the mechanics:
 https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 "
 
-	| identityMatrix householderVector i |
+	| identityMatrix householderVector i matrixOfMinor |
 	identityMatrix := PMSymmetricMatrix identity: colSize.
 	1 to: self numberOfColumns do: [ :col | 
 		| columnVectorFromRMatrix householderMatrix v |
@@ -40,10 +40,12 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 		                     -
 		                     ((householderVector at: 1) * v tensorProduct: v).
 		q := q * householderMatrix.
-		i := r minor: col - 1 and: col - 1.
-		i := i - ((householderVector at: 2) tensorProduct:
-			      (householderVector at: 1) * (householderVector at: 2) * i).
-		i rows withIndexDo: [ :aRow :index | 
+		matrixOfMinor := r minor: col - 1 and: col - 1.
+		matrixOfMinor := matrixOfMinor
+		                 - ((householderVector at: 2) tensorProduct:
+				                  (householderVector at: 1)
+				                  * (householderVector at: 2) * matrixOfMinor).
+		matrixOfMinor rowsWithIndexDo: [ :aRow :index | 
 			aRow withIndexDo: [ :n :c | 
 				r
 					rowAt: col + index - 1

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -67,7 +67,8 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 PMQRDecomposition >> decomposeWithPivot [
 
 	| identMat householderVector i vectorOfNormSquareds rank mx pivot |
-	vectorOfNormSquareds := matrixToDecompose columnsCollect: [ :columnVector | columnVector * columnVector ].
+	vectorOfNormSquareds := matrixToDecompose columnsCollect: [ 
+		                        :columnVector | columnVector * columnVector ].
 	mx := vectorOfNormSquareds indexOf: vectorOfNormSquareds max.
 	pivot := Array new: vectorOfNormSquareds size.
 	rank := 0.
@@ -79,7 +80,7 @@ PMQRDecomposition >> decomposeWithPivot [
 	vectorOfNormSquareds swap: rank with: mx.
 	householderVector := (r columnVectorAt: rank size: colSize)
 		                     householder.
-	i := (PMVector new: rank - 1 withAll: 0) , (householderVector at: 2).
+	i := (PMVector zeros: rank - 1) , (householderVector at: 2).
 	q := q
 	     * (identMat - ((householderVector at: 1) * i tensorProduct: i)).
 	i := r minor: rank - 1 and: rank - 1.
@@ -96,13 +97,18 @@ PMQRDecomposition >> decomposeWithPivot [
 	rank + 1 to: vectorOfNormSquareds size do: [ :ind | 
 		vectorOfNormSquareds
 			at: ind
-			put: (vectorOfNormSquareds at: ind) - (r rowAt: rank columnAt: ind) squared ].
+			put:
+			(vectorOfNormSquareds at: ind)
+			- (r rowAt: rank columnAt: ind) squared ].
 	rank < vectorOfNormSquareds size
 		ifTrue: [ 
-			mx := (vectorOfNormSquareds copyFrom: rank + 1 to: vectorOfNormSquareds size) max.
+			mx := (vectorOfNormSquareds
+				       copyFrom: rank + 1
+				       to: vectorOfNormSquareds size) max.
 			(mx closeTo: 0) ifTrue: [ mx := 0 ].
 			mx := mx > 0
-				      ifTrue: [ vectorOfNormSquareds indexOf: mx startingAt: rank + 1 ]
+				      ifTrue: [ 
+				      vectorOfNormSquareds indexOf: mx startingAt: rank + 1 ]
 				      ifFalse: [ 0 ] ]
 		ifFalse: [ mx := 0 ].
 	mx > 0 ] whileTrue.

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -66,7 +66,7 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 { #category : #arithmetic }
 PMQRDecomposition >> decomposeWithPivot [
 
-	| identMat householderVector i vectorOfNormSquareds rank mx pivot |
+	| identMat householderVector i v vectorOfNormSquareds rank mx pivot |
 	vectorOfNormSquareds := matrixToDecompose columnsCollect: [ 
 		                        :columnVector | columnVector * columnVector ].
 	mx := vectorOfNormSquareds indexOf: vectorOfNormSquareds max.
@@ -80,9 +80,9 @@ PMQRDecomposition >> decomposeWithPivot [
 	vectorOfNormSquareds swap: rank with: mx.
 	householderVector := (r columnVectorAt: rank size: colSize)
 		                     householder.
-	i := (PMVector zeros: rank - 1) , (householderVector at: 2).
+	v := (PMVector zeros: rank - 1) , (householderVector at: 2).
 	q := q
-	     * (identMat - ((householderVector at: 1) * i tensorProduct: i)).
+	     * (identMat - ((householderVector at: 1) * v tensorProduct: v)).
 	i := r minor: rank - 1 and: rank - 1.
 	i := i - ((householderVector at: 2) tensorProduct:
 		      (householderVector at: 1) * (householderVector at: 2) * i).

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -87,13 +87,13 @@ PMQRDecomposition >> decomposeWithPivot [
 	i := i - ((householderVector at: 2) tensorProduct:
 		      (householderVector at: 1) * (householderVector at: 2) * i).
 	i rows withIndexDo: [ :aRow :index | 
-		aRow withIndexDo: [ :n :c | 
+		aRow withIndexDo: [ :element :column | 
 			r
 				rowAt: rank + index - 1
-				columnAt: rank + c - 1
-				put: ((n closeTo: 0)
+				columnAt: rank + column - 1
+				put: ((element closeTo: 0)
 						 ifTrue: [ 0 ]
-						 ifFalse: [ n ]) ] ].
+						 ifFalse: [ element ]) ] ].
 	rank + 1 to: vectorOfNormSquareds size do: [ :ind | 
 		vectorOfNormSquareds
 			at: ind

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -66,17 +66,17 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 { #category : #arithmetic }
 PMQRDecomposition >> decomposeWithPivot [
 
-	| identMat householderVector i vectorOfnormSquareds rank mx pivot |
-	vectorOfnormSquareds := matrixToDecompose columnsCollect: [ :columnVector | columnVector * columnVector ].
-	mx := vectorOfnormSquareds indexOf: vectorOfnormSquareds max.
-	pivot := Array new: vectorOfnormSquareds size.
+	| identMat householderVector i vectorOfNormSquareds rank mx pivot |
+	vectorOfNormSquareds := matrixToDecompose columnsCollect: [ :columnVector | columnVector * columnVector ].
+	mx := vectorOfNormSquareds indexOf: vectorOfNormSquareds max.
+	pivot := Array new: vectorOfNormSquareds size.
 	rank := 0.
 	identMat := PMSymmetricMatrix identity: colSize.
 	[ 
 	rank := rank + 1.
 	pivot at: rank put: mx.
 	r swapColumn: rank withColumn: mx.
-	vectorOfnormSquareds swap: rank with: mx.
+	vectorOfNormSquareds swap: rank with: mx.
 	householderVector := (r columnVectorAt: rank size: colSize)
 		                     householder.
 	i := (PMVector new: rank - 1 withAll: 0) , (householderVector at: 2).
@@ -93,16 +93,16 @@ PMQRDecomposition >> decomposeWithPivot [
 				put: ((n closeTo: 0)
 						 ifTrue: [ 0 ]
 						 ifFalse: [ n ]) ] ].
-	rank + 1 to: vectorOfnormSquareds size do: [ :ind | 
-		vectorOfnormSquareds
+	rank + 1 to: vectorOfNormSquareds size do: [ :ind | 
+		vectorOfNormSquareds
 			at: ind
-			put: (vectorOfnormSquareds at: ind) - (r rowAt: rank columnAt: ind) squared ].
-	rank < vectorOfnormSquareds size
+			put: (vectorOfNormSquareds at: ind) - (r rowAt: rank columnAt: ind) squared ].
+	rank < vectorOfNormSquareds size
 		ifTrue: [ 
-			mx := (vectorOfnormSquareds copyFrom: rank + 1 to: vectorOfnormSquareds size) max.
+			mx := (vectorOfNormSquareds copyFrom: rank + 1 to: vectorOfNormSquareds size) max.
 			(mx closeTo: 0) ifTrue: [ mx := 0 ].
 			mx := mx > 0
-				      ifTrue: [ vectorOfnormSquareds indexOf: mx startingAt: rank + 1 ]
+				      ifTrue: [ vectorOfNormSquareds indexOf: mx startingAt: rank + 1 ]
 				      ifFalse: [ 0 ] ]
 		ifFalse: [ mx := 0 ].
 	mx > 0 ] whileTrue.

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -74,8 +74,8 @@ PMQRDecomposition >> decomposeWithPivot [
 	pivot := Array new: lengthArray size.
 	rank := 0.
 	r := self initialRMatrix.
-	q := self initialQMatrix .
-	identMat := q deepCopy.
+	q := self initialQMatrix.
+	identMat := PMSymmetricMatrix identity: colSize.
 	[ 
 	rank := rank + 1.
 	pivot at: rank put: mx.

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -67,7 +67,59 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 
 { #category : #arithmetic }
 PMQRDecomposition >> decomposeWithPivot [
-	^ matrixToDecompose qrFactorizationWithPivoting 
+
+	| identMat q r hh i lengthArray rank mx pivot |
+	lengthArray := matrixToDecompose columnsCollect: [ :col | col * col ].
+	mx := lengthArray indexOf: lengthArray max.
+	pivot := Array new: lengthArray size.
+	rank := 0.
+	r := self initialRMatrix.
+	q := PMSymmetricMatrix identity: colSize.
+	identMat := q deepCopy.
+	[ 
+	rank := rank + 1.
+	pivot at: rank put: mx.
+	r swapColumn: rank withColumn: mx.
+	lengthArray swap: rank with: mx.
+	hh := ((r columnAt: rank) copyFrom: rank to: colSize) householder.
+	i := (PMVector new: rank - 1 withAll: 0) , (hh at: 2).
+	q := q * (identMat - ((hh at: 1) * i tensorProduct: i)).
+	i := PMMatrix rows:
+		     ((r rows allButFirst: rank - 1) collect: [ :aRow | 
+			      aRow allButFirst: rank - 1 ]).
+	i := i - ((hh at: 2) tensorProduct: (hh at: 1) * (hh at: 2) * i).
+	i rows withIndexDo: [ :aRow :index | 
+		aRow withIndexDo: [ :n :c | 
+			r
+				rowAt: rank + index - 1
+				columnAt: rank + c - 1
+				put: ((n closeTo: 0)
+						 ifTrue: [ 0 ]
+						 ifFalse: [ n ]) ] ].
+	rank + 1 to: lengthArray size do: [ :ind | 
+		lengthArray
+			at: ind
+			put: (lengthArray at: ind) - (r rowAt: rank columnAt: ind) squared ].
+	rank < lengthArray size
+		ifTrue: [ 
+			mx := (lengthArray copyFrom: rank + 1 to: lengthArray size) max.
+			(mx closeTo: 0) ifTrue: [ mx := 0 ].
+			mx := mx > 0
+				      ifTrue: [ lengthArray indexOf: mx startingAt: rank + 1 ]
+				      ifFalse: [ 0 ] ]
+		ifFalse: [ mx := 0 ].
+	mx > 0 ] whileTrue.
+	i := 0.
+	[ (r rowAt: colSize) allSatisfy: [ :n | n = 0 ] ] whileTrue: [ 
+		i := i + 1.
+		colSize := colSize - 1 ].
+	i > 0 ifTrue: [ 
+		r := PMMatrix rows: (r rows copyFrom: 1 to: colSize).
+		i := q numberOfColumns - i.
+		pivot := pivot copyFrom: 1 to: i.
+		q := PMMatrix rows:
+			     (q rows collect: [ :row | row copyFrom: 1 to: i ]) ].
+	^ Array with: q with: r with: pivot
 ]
 
 { #category : #private }

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -32,7 +32,7 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 	q := self initialQMatrix.
 	identityMatrix := PMSymmetricMatrix identity: colSize.
 	1 to: self numberOfColumns do: [ :col | 
-		| columnVectorFromRMatrix householderMatrix rowIndex columnIndex |
+		| columnVectorFromRMatrix householderMatrix |
 		columnVectorFromRMatrix := r columnVectorAt: col size: colSize.
 		householderVector := columnVectorFromRMatrix householder.
 		i := (PMVector zeros: col - 1) , (householderVector at: 2).
@@ -40,9 +40,7 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 		                     -
 		                     ((householderVector at: 1) * i tensorProduct: i).
 		q := q * householderMatrix.
-		rowIndex := col - 1.
-		columnIndex := col - 1.
-		i := r minor: rowIndex and: columnIndex.
+		i := r minor: col - 1 and: col - 1.
 		i := i - ((householderVector at: 2) tensorProduct:
 			      (householderVector at: 1) * (householderVector at: 2) * i).
 		i rows withIndexDo: [ :aRow :index | 
@@ -81,7 +79,7 @@ PMQRDecomposition >> decomposeWithPivot [
 	pivot at: rank put: mx.
 	r swapColumn: rank withColumn: mx.
 	lengthArray swap: rank with: mx.
-	hh := ((r columnAt: rank) copyFrom: rank to: colSize) householder.
+	hh := (r columnVectorAt: rank size: colSize) householder.
 	i := (PMVector new: rank - 1 withAll: 0) , (hh at: 2).
 	q := q * (identMat - ((hh at: 1) * i tensorProduct: i)).
 	i := r minor: rank - 1 and: rank - 1.

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -84,9 +84,7 @@ PMQRDecomposition >> decomposeWithPivot [
 	hh := ((r columnAt: rank) copyFrom: rank to: colSize) householder.
 	i := (PMVector new: rank - 1 withAll: 0) , (hh at: 2).
 	q := q * (identMat - ((hh at: 1) * i tensorProduct: i)).
-	i := PMMatrix rows:
-		     ((r rows allButFirst: rank - 1) collect: [ :aRow | 
-			      aRow allButFirst: rank - 1 ]).
+	i := r minor: rank - 1 and: rank - 1.
 	i := i - ((hh at: 2) tensorProduct: (hh at: 1) * (hh at: 2) * i).
 	i rows withIndexDo: [ :aRow :index | 
 		aRow withIndexDo: [ :n :c | 

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -113,7 +113,7 @@ PMQRDecomposition >> decomposeWithPivot [
 		ifFalse: [ mx := 0 ].
 	mx > 0 ] whileTrue.
 	i := 0.
-	[ (r rowAt: colSize) allSatisfy: [ :n | n = 0 ] ] whileTrue: [ 
+	[ (r rowAt: colSize) isZero ] whileTrue: [ 
 		i := i + 1.
 		colSize := colSize - 1 ].
 	i > 0 ifTrue: [ 

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -88,7 +88,7 @@ PMQRDecomposition >> decomposeWithPivot [
 	                 - ((householderVector at: 2) tensorProduct:
 			                  (householderVector at: 1)
 			                  * (householderVector at: 2) * matrixOfMinor).
-	matrixOfMinor rows withIndexDo: [ :aRow :index | 
+	matrixOfMinor rowsWithIndexDo: [ :aRow :index | 
 		aRow withIndexDo: [ :element :column | 
 			r
 				rowAt: rank + index - 1

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -65,6 +65,11 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 	^ Array with: q with: r
 ]
 
+{ #category : #arithmetic }
+PMQRDecomposition >> decomposeWithPivot [
+	^ matrixToDecompose qrFactorizationWithPivoting 
+]
+
 { #category : #private }
 PMQRDecomposition >> initialQMatrix [
 

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -32,7 +32,7 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 	q := self initialQMatrix.
 	identityMatrix := PMSymmetricMatrix identity: colSize.
 	1 to: self numberOfColumns do: [ :col | 
-		| columnVectorFromRMatrix householderMatrix |
+		| columnVectorFromRMatrix householderMatrix dimension |
 		columnVectorFromRMatrix := r columnVectorAt: col size: colSize.
 		householderVector := columnVectorFromRMatrix householder.
 		i := (PMVector zeros: col - 1) , (householderVector at: 2).
@@ -40,9 +40,10 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 		                     -
 		                     ((householderVector at: 1) * i tensorProduct: i).
 		q := q * householderMatrix.
+		dimension := col - 1.
 		i := PMMatrix rows:
-			     ((r rows allButFirst: col - 1) collect: [ :aRow | 
-				      aRow allButFirst: col - 1 ]).
+			     ((r rows allButFirst: dimension) collect: [ :aRow | 
+				      aRow allButFirst: dimension ]).
 		i := i - ((householderVector at: 2) tensorProduct:
 			      (householderVector at: 1) * (householderVector at: 2) * i).
 		i rows withIndexDo: [ :aRow :index | 

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -68,13 +68,13 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 { #category : #arithmetic }
 PMQRDecomposition >> decomposeWithPivot [
 
-	| identMat householderVector i v vectorOfNormSquareds rank mx pivot matrixOfMinor |
+	| identityMatrix householderVector i v vectorOfNormSquareds rank mx pivot matrixOfMinor |
 	vectorOfNormSquareds := matrixToDecompose columnsCollect: [ 
 		                        :columnVector | columnVector * columnVector ].
 	mx := vectorOfNormSquareds indexOf: vectorOfNormSquareds max.
 	pivot := Array new: vectorOfNormSquareds size.
 	rank := 0.
-	identMat := PMSymmetricMatrix identity: colSize.
+	identityMatrix := PMSymmetricMatrix identity: colSize.
 	[ 
 	| householderMatrix |
 	rank := rank + 1.
@@ -84,7 +84,7 @@ PMQRDecomposition >> decomposeWithPivot [
 	householderVector := (r columnVectorAt: rank size: colSize)
 		                     householder.
 	v := (PMVector zeros: rank - 1) , (householderVector at: 2).
-	householderMatrix := identMat
+	householderMatrix := identityMatrix
 	                     -
 	                     ((householderVector at: 1) * v tensorProduct: v).
 	q := q * householderMatrix.

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -74,7 +74,7 @@ PMQRDecomposition >> decomposeWithPivot [
 	pivot := Array new: lengthArray size.
 	rank := 0.
 	r := self initialRMatrix.
-	q := PMSymmetricMatrix identity: colSize.
+	q := self initialQMatrix .
 	identMat := q deepCopy.
 	[ 
 	rank := rank + 1.

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -66,17 +66,17 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 { #category : #arithmetic }
 PMQRDecomposition >> decomposeWithPivot [
 
-	| identMat householderVector i lengthArray rank mx pivot |
-	lengthArray := matrixToDecompose columnsCollect: [ :col | col * col ].
-	mx := lengthArray indexOf: lengthArray max.
-	pivot := Array new: lengthArray size.
+	| identMat householderVector i normSquaredVector rank mx pivot |
+	normSquaredVector := matrixToDecompose columnsCollect: [ :columnVector | columnVector * columnVector ].
+	mx := normSquaredVector indexOf: normSquaredVector max.
+	pivot := Array new: normSquaredVector size.
 	rank := 0.
 	identMat := PMSymmetricMatrix identity: colSize.
 	[ 
 	rank := rank + 1.
 	pivot at: rank put: mx.
 	r swapColumn: rank withColumn: mx.
-	lengthArray swap: rank with: mx.
+	normSquaredVector swap: rank with: mx.
 	householderVector := (r columnVectorAt: rank size: colSize)
 		                     householder.
 	i := (PMVector new: rank - 1 withAll: 0) , (householderVector at: 2).
@@ -93,16 +93,16 @@ PMQRDecomposition >> decomposeWithPivot [
 				put: ((n closeTo: 0)
 						 ifTrue: [ 0 ]
 						 ifFalse: [ n ]) ] ].
-	rank + 1 to: lengthArray size do: [ :ind | 
-		lengthArray
+	rank + 1 to: normSquaredVector size do: [ :ind | 
+		normSquaredVector
 			at: ind
-			put: (lengthArray at: ind) - (r rowAt: rank columnAt: ind) squared ].
-	rank < lengthArray size
+			put: (normSquaredVector at: ind) - (r rowAt: rank columnAt: ind) squared ].
+	rank < normSquaredVector size
 		ifTrue: [ 
-			mx := (lengthArray copyFrom: rank + 1 to: lengthArray size) max.
+			mx := (normSquaredVector copyFrom: rank + 1 to: normSquaredVector size) max.
 			(mx closeTo: 0) ifTrue: [ mx := 0 ].
 			mx := mx > 0
-				      ifTrue: [ lengthArray indexOf: mx startingAt: rank + 1 ]
+				      ifTrue: [ normSquaredVector indexOf: mx startingAt: rank + 1 ]
 				      ifFalse: [ 0 ] ]
 		ifFalse: [ mx := 0 ].
 	mx > 0 ] whileTrue.

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -66,7 +66,7 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 { #category : #arithmetic }
 PMQRDecomposition >> decomposeWithPivot [
 
-	| identMat q r hh i lengthArray rank mx pivot |
+	| identMat q r householderVector i lengthArray rank mx pivot |
 	lengthArray := matrixToDecompose columnsCollect: [ :col | col * col ].
 	mx := lengthArray indexOf: lengthArray max.
 	pivot := Array new: lengthArray size.
@@ -79,11 +79,11 @@ PMQRDecomposition >> decomposeWithPivot [
 	pivot at: rank put: mx.
 	r swapColumn: rank withColumn: mx.
 	lengthArray swap: rank with: mx.
-	hh := (r columnVectorAt: rank size: colSize) householder.
-	i := (PMVector new: rank - 1 withAll: 0) , (hh at: 2).
-	q := q * (identMat - ((hh at: 1) * i tensorProduct: i)).
+	householderVector := (r columnVectorAt: rank size: colSize) householder.
+	i := (PMVector new: rank - 1 withAll: 0) , (householderVector at: 2).
+	q := q * (identMat - ((householderVector at: 1) * i tensorProduct: i)).
 	i := r minor: rank - 1 and: rank - 1.
-	i := i - ((hh at: 2) tensorProduct: (hh at: 1) * (hh at: 2) * i).
+	i := i - ((householderVector at: 2) tensorProduct: (householderVector at: 1) * (householderVector at: 2) * i).
 	i rows withIndexDo: [ :aRow :index | 
 		aRow withIndexDo: [ :n :c | 
 			r

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -18,7 +18,7 @@ PMQRDecomposition class >> of: matrix [
 	^ self new of: matrix
 ]
 
-{ #category : #private }
+{ #category : #arithmetic }
 PMQRDecomposition >> decompose [
 
 	"

--- a/src/Math-Matrix/PMQRDecomposition.class.st
+++ b/src/Math-Matrix/PMQRDecomposition.class.st
@@ -66,7 +66,7 @@ https://en.wikipedia.org/wiki/QR_decomposition#Using_Householder_reflections
 { #category : #arithmetic }
 PMQRDecomposition >> decomposeWithPivot [
 
-	| identMat householderVector i v vectorOfNormSquareds rank mx pivot |
+	| identMat householderVector i v vectorOfNormSquareds rank mx pivot matrixOfMinor |
 	vectorOfNormSquareds := matrixToDecompose columnsCollect: [ 
 		                        :columnVector | columnVector * columnVector ].
 	mx := vectorOfNormSquareds indexOf: vectorOfNormSquareds max.
@@ -83,10 +83,12 @@ PMQRDecomposition >> decomposeWithPivot [
 	v := (PMVector zeros: rank - 1) , (householderVector at: 2).
 	q := q
 	     * (identMat - ((householderVector at: 1) * v tensorProduct: v)).
-	i := r minor: rank - 1 and: rank - 1.
-	i := i - ((householderVector at: 2) tensorProduct:
-		      (householderVector at: 1) * (householderVector at: 2) * i).
-	i rows withIndexDo: [ :aRow :index | 
+	matrixOfMinor := r minor: rank - 1 and: rank - 1.
+	matrixOfMinor := matrixOfMinor
+	                 - ((householderVector at: 2) tensorProduct:
+			                  (householderVector at: 1)
+			                  * (householderVector at: 2) * matrixOfMinor).
+	matrixOfMinor rows withIndexDo: [ :aRow :index | 
 		aRow withIndexDo: [ :element :column | 
 			r
 				rowAt: rank + index - 1

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -653,6 +653,22 @@ PMMatrixTest >> testMatrixTrace [
 ]
 
 { #category : #'linear algebra' }
+PMMatrixTest >> testMinorsOfNonSquareMatrix [
+
+	| matrix expected |
+	matrix := PMMatrix rows: { 
+			          { 1. 2 }.
+			          { 6. 7 }.
+			          { 5. 4 } }.
+
+	expected := PMMatrix rows: { 
+			            { 7 }.
+			            { 4 } }.
+	self assert: (matrix minor: 0 and: 0) equals: matrix.
+	self assert: (matrix minor: 1 and: 1) equals: expected
+]
+
+{ #category : #'linear algebra' }
 PMMatrixTest >> testMinorsOfSquareMatrix [
 
 	| matrix expected |

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -665,7 +665,8 @@ PMMatrixTest >> testMinorsOfSquareMatrix [
 			            { 7. 8 }.
 			            { 4. 1 } }.
 	self assert: (matrix minor: 0 and: 0) equals: matrix.
-	self assert: (matrix minor: 1 and: 1) equals: expected
+	self assert: (matrix minor: 1 and: 1) equals: expected.
+	self assert: (matrix minor: 2 and: 2) equals: (PMMatrix rows: {{ 1 }})
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -682,7 +682,9 @@ PMMatrixTest >> testMinorsOfSquareMatrix [
 			            { 4. 1 } }.
 	self assert: (matrix minor: 0 and: 0) equals: matrix.
 	self assert: (matrix minor: 1 and: 1) equals: expected.
-	self assert: (matrix minor: 2 and: 2) equals: (PMMatrix rows: {{ 1 }})
+	self
+		assert: (matrix minor: 2 and: 2)
+		equals: (PMMatrix rows: { { 1 } })
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -664,6 +664,7 @@ PMMatrixTest >> testMinorsOfSquareMatrix [
 	expected := PMMatrix rows: { 
 			            { 7. 8 }.
 			            { 4. 1 } }.
+	self assert: (matrix minor: 0 and: 0) equals: matrix.
 	self assert: (matrix minor: 1 and: 1) equals: expected
 ]
 

--- a/src/Math-Tests-Matrix/PMMatrixTest.class.st
+++ b/src/Math-Tests-Matrix/PMMatrixTest.class.st
@@ -652,6 +652,21 @@ PMMatrixTest >> testMatrixTrace [
 	self assert: a tr equals: 15
 ]
 
+{ #category : #'linear algebra' }
+PMMatrixTest >> testMinorsOfSquareMatrix [
+
+	| matrix expected |
+	matrix := PMMatrix rows: { 
+			          { 1. 2. 3 }.
+			          { 6. 7. 8 }.
+			          { 5. 4. 1 } }.
+
+	expected := PMMatrix rows: { 
+			            { 7. 8 }.
+			            { 4. 1 } }.
+	self assert: (matrix minor: 1 and: 1) equals: expected
+]
+
 { #category : #tests }
 PMMatrixTest >> testOnesMatrix [
 	| a |

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -30,7 +30,7 @@ PMQRTest >> assert: inverse isMoorePenroseInverseOf: aMatrix [
 { #category : #tests }
 PMQRTest >> testDecompositionOfMatrixCausingErraticFailure [
 
-	| a qrDecomposition matricesAndPivot q r expectedMatrix |
+	| a qrDecomposition matricesAndPivot q r expectedMatrix pivot |
 	a := PMSymmetricMatrix rows:
 		     #( #( 0.41929313699681925 0.05975350554089691
 		           0.2771676258543356 0.35628773381760703 )
@@ -55,8 +55,9 @@ PMQRTest >> testDecompositionOfMatrixCausingErraticFailure [
 		                        0.35628773381760703 0.28814463284245906 ) ).
 	q := matricesAndPivot at: 1.
 	r := matricesAndPivot at: 2.
-	self assert: q * r closeTo: expectedMatrix .
-	self assert: (matricesAndPivot at: 3) equals: #( 3 4 3 nil )
+	pivot := matricesAndPivot at: 3.
+	self assert: q * r closeTo: expectedMatrix.
+	self assert: pivot equals: #( 3 4 3 nil )
 ]
 
 { #category : #tests }

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -28,6 +28,38 @@ PMQRTest >> assert: inverse isMoorePenroseInverseOf: aMatrix [
 ]
 
 { #category : #tests }
+PMQRTest >> testDecompositionOfMatrixCausingErraticFailure [
+
+	| a qrDecomposition matricesAndPivot q r expectedMatrix |
+	a := PMSymmetricMatrix rows:
+		     #( #( 0.41929313699681925 0.05975350554089691
+		           0.2771676258543356 0.35628773381760703 )
+		        #( 0.05975350554089691 0.12794227252152854
+		           0.3257742693302102 0.28814463284245906 )
+		        #( 0.2771676258543356 0.3257742693302102 0.8468441832097453
+		           0.9101872061892353 )
+		        #( 0.35628773381760703 0.28814463284245906
+		           0.9101872061892353 0.5163744224777326 ) ).
+
+	qrDecomposition := PMQRDecomposition of: a.
+	matricesAndPivot := qrDecomposition decomposeWithPivot.
+
+	expectedMatrix := PMMatrix rows:
+		                  #( #( 0.2771676258543356 0.35628773381760703
+		                        0.41929313699681925 0.05975350554089691 )
+		                     #( 0.3257742693302102 0.28814463284245906
+		                        0.05975350554089691 0.12794227252152854 )
+		                     #( 0.8468441832097453 0.9101872061892353
+		                        0.2771676258543356 0.3257742693302102 )
+		                     #( 0.9101872061892353 0.5163744224777326
+		                        0.35628773381760703 0.28814463284245906 ) ).
+	q := matricesAndPivot at: 1.
+	r := matricesAndPivot at: 2.
+	self assert: q * r closeTo: expectedMatrix .
+	self assert: (matricesAndPivot at: 3) equals: #( 3 4 3 nil )
+]
+
+{ #category : #tests }
 PMQRTest >> testHorizontalRectangularMatrixCannotBeDecomposed [
 
 	| horizontalRectangularMatrix |

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -170,6 +170,22 @@ PMQRTest >> testRank [
 ]
 
 { #category : #tests }
+PMQRTest >> testSimpleQRDecomposition [
+
+	| a qrDecomposition decomposition |
+	a := PMMatrix rows: { 
+			     { 12. -51. 4 }.
+			     { 6. 167. -68 }.
+			     { -4. 24. -41 } }.
+
+	qrDecomposition := PMQRDecomposition of: a.
+
+	decomposition := qrDecomposition decompose.
+	decomposition first * decomposition second.
+	self assert: decomposition first * decomposition second equals: a
+]
+
+{ #category : #tests }
 PMQRTest >> testVectorHouseholder [
 
 	"result is householdermatrix * v"

--- a/src/Math-Tests-Matrix/PMQRTest.class.st
+++ b/src/Math-Tests-Matrix/PMQRTest.class.st
@@ -186,6 +186,29 @@ PMQRTest >> testSimpleQRDecomposition [
 ]
 
 { #category : #tests }
+PMQRTest >> testSimpleQRDecompositionWithPivot [
+
+	| a qrDecomposition decomposition expected |
+	a := PMMatrix rows: { 
+			     { 12. -51. 4 }.
+			     { 6. 167. -68 }.
+			     { -4. 24. -41 } }.
+
+	qrDecomposition := PMQRDecomposition of: a.
+
+	decomposition := qrDecomposition decomposeWithPivot.
+	decomposition first * decomposition second.
+
+	expected := PMMatrix rows: { 
+			            { -51. 4. 12 }.
+			            { 167. -68. 6 }.
+			            { 24. -41. -4 } }.
+	self
+		assert: decomposition first * decomposition second
+		closeTo: expected
+]
+
+{ #category : #tests }
 PMQRTest >> testVectorHouseholder [
 
 	"result is householdermatrix * v"


### PR DESCRIPTION
This work continues the refactoring, and **has introduced a test that shows why the Moore Penrose Inverse test fails randomly: the pivot of the QR decomposition contains a `nil`**.

I will try to delve deeper into why the pivot has a nil in it at all, and what the answer should be. I will give myself a few days. If I get nowhere, I will make this a full PR ready for review.